### PR TITLE
require sass

### DIFF
--- a/lib/bourbon/sass_extensions.rb
+++ b/lib/bourbon/sass_extensions.rb
@@ -1,4 +1,6 @@
 module Bourbon::SassExtensions
 end
 
+require "sass"
+
 require File.join(File.dirname(__FILE__), "/sass_extensions/functions")


### PR DESCRIPTION
Getting "uninitialized constant Sass (NameError)" when running generators from a Rails template with bourbon in the Gemfile. Requiring sass in lib/bourbon/sass_extensions.rb resolves the issue.
