### PR TITLE
Fix for linear-gradient mixin on older webkit browsers

### DIFF
--- a/app/assets/stylesheets/css3/_linear-gradient.scss
+++ b/app/assets/stylesheets/css3/_linear-gradient.scss
@@ -15,10 +15,11 @@
   }
 
   $full: compact($G1, $G2, $G3, $G4, $G5, $G6, $G7, $G8, $G9, $G10);
+  $GLast: nth($full, length($full));
 
   background-color:  nth($G1, 1);
-  background-image:  -webkit-gradient(linear, left top, left bottom, from($G1), to($G2)); /* Saf4+, Chrome */
-  background-image:  -webkit-linear-gradient($pos, $full);
+  background-image:  -webkit-gradient(linear, left top, left bottom, from(nth($G1, 1)), to(nth($GLast, 1))); /* Saf4, < iOS 5, Android Webkit */
+  background-image:  -webkit-linear-gradient($pos, $full); /* Saf5.1+, Chrome */
   background-image:     -moz-linear-gradient($pos, $full);
   background-image:      -ms-linear-gradient($pos, $full);
   background-image:       -o-linear-gradient($pos, $full);


### PR DESCRIPTION
The current linear-gradient mixin is generating incorrect CSS with the -webkit-gradient value.  For example, it currently generates this:
-webkit-gradient(linear, left top, left bottom, from(#eece64 0%), to(#b69c43 50%))

This is because variables $G1 and $G2 are actually lists, not single color values. 

Newer Chrome and Safari browsers are not affected because they simply read the -webkit-linear-gradient rule which is also generated by the linear-gradient mixin. Unfortunately, older webkit browsers do not support this rule and only support the -webkit-gradient(linear, ...). Devices that have this older webkit version includes all iOS devices before iOS5 and all Android devices before 3.0 (could also include 3.0, I don't have a honey comb device to test).

This change modifies the -webkit-gradient to take the first and last values of the parameters and do a simple linear gradient between them. Someone with a bit more Sass muscle than I could enable the rest of the color stops by generating a rule that looks something like: 
background-image: -webkit-gradient(linear, 0% 0%, 0% 100%, from(rgb(242, 246, 248)), color-stop(0.5, rgb(216, 225, 231)), color-stop(0.51, rgb(181, 198, 208)), to(rgb(224, 239, 249)))
