### PR TITLE
Fix bourbon:install rake task when the Rails.root path contains spaces.

### DIFF
--- a/lib/tasks/install.rake
+++ b/lib/tasks/install.rake
@@ -4,9 +4,9 @@ namespace :bourbon do
   task :install, [:sass_path] do |t, args|
     args.with_defaults :sass_path => 'public/stylesheets/sass'
     source_root = File.expand_path(File.join(File.dirname(__FILE__), '..', '..'))
-    bourbon_path = File.expand_path(File.join(Rails.root, 'public/stylesheets/sass', 'bourbon')).shellescape
-    `mkdir -p #{bourbon_path}`
-    `cp -a #{source_root}/app/assets/stylesheets/* #{bourbon_path}`
-    `find #{bourbon_path} -name "*.css.scss" | while read i; do mv "$i" "${i%.css.scss}.scss"; done`
+    bourbon_sass_path = Rails.root.join(args.sass_path, 'bourbon').to_s.shellescape
+    `mkdir -p #{bourbon_sass_path}`
+    `cp -a #{source_root}/app/assets/stylesheets/* #{bourbon_sass_path}`
+    `find #{bourbon_sass_path} -name "*.css.scss" | while read i; do mv "$i" "${i%.css.scss}.scss"; done`
   end
 end


### PR DESCRIPTION
This might not work on other platforms, or rails versions.

Fix works for me with rails 3.0.10, ruby 1.9.2 under Mac OS X.
