### PR TITLE
Fixes undefined method `exist?' for Dir:Class

### DIFF
--- a/lib/bourbon/generator.rb
+++ b/lib/bourbon/generator.rb
@@ -36,7 +36,7 @@ module Bourbon
     private
 
     def bourbon_files_already_exist?
-      Dir.exist?("bourbon")
+      File.directory?("bourbon")
     end
 
     def install_files


### PR DESCRIPTION
I tried to run:

bourbon install

on my mac and the error was triggered on line 39.

I fixed it by replace Dir.exists? with File.directory?
