### PR TITLE
A mixin to help clear the element it is mixed into

### DIFF
--- a/app/assets/stylesheets/css3/_cleared.scss
+++ b/app/assets/stylesheets/css3/_cleared.scss
@@ -1,0 +1,10 @@
+@mixin cleared ($clear: both) {
+    &:after {
+        clear: $clear;
+        display: block;
+        content: " ";
+        font-size: 0;
+        height: 0;
+        visibility: hidden;
+    }
+}


### PR DESCRIPTION
I find myself having to clear a lot of elements and thought this mixin should make its way into `bourbon` since it could potentially see a lot of use.

``` css
#foo {
  @include cleared;
  float: left;
}
```

allows one to 

``` html
<div id="foo">To the left, to the left</div>

I should clear
```

rather than having to do

``` html
<div id="foo">To the left, to the left</div>
<div style="clear: both; visibility: hidden"></div>

I should clear
```

Additionally, can also

``` css
@include cleared(left);
@include cleared(right);
```
