### PR TITLE
Allow `bourbon generate` to run on Ruby 1.8

### DIFF
--- a/lib/bourbon/generator.rb
+++ b/lib/bourbon/generator.rb
@@ -36,7 +36,7 @@ module Bourbon
     private
 
     def bourbon_files_already_exist?
-      Dir.exist?("bourbon")
+      File.directory?("bourbon")
     end
 
     def install_files


### PR DESCRIPTION
Currently it only runs on 1.9.2, because `Dir.exist?` is 1.9-only.
