### PR TITLE
-moz-inline-block is obsolete

### DIFF
--- a/app/assets/stylesheets/css3/_inline-block.scss
+++ b/app/assets/stylesheets/css3/_inline-block.scss
@@ -1,6 +1,5 @@
 // Legacy support for inline-block in IE7 (maybe IE6)
 @mixin inline-block {
-  display: -moz-inline-box;
   -moz-box-orient: vertical;
   display: inline-block;
   vertical-align: baseline;


### PR DESCRIPTION
Source: https://developer.mozilla.org/en/CSS_Reference/Mozilla_Extensions#display

Compatibility for `inline-block` was added in FF3.

FF2 used to require `-moz-inline-stack` but even that wouldn't work properly so I think we can safely leave it out. (source: http://blog.mozilla.com/webdev/2009/02/20/cross-browser-inline-block/)

Also, do we really need the `-moz-box-orient`?
