### PR TITLE
Remove -o and -ms vendor prefix definitions from border-radius mixin.

### DIFF
--- a/app/assets/stylesheets/css3/_border-radius.scss
+++ b/app/assets/stylesheets/css3/_border-radius.scss
@@ -1,8 +1,6 @@
 @mixin border-radius ($radii) {
   -webkit-border-radius: $radii;
      -moz-border-radius: $radii;
-      -ms-border-radius: $radii;
-       -o-border-radius: $radii;
           border-radius: $radii;
 }
 
@@ -10,8 +8,6 @@
   -webkit-border-top-left-radius: $radii;
      -moz-border-top-left-radius: $radii;
       -moz-border-radius-topleft: $radii;
-      -ms-border-top-left-radius: $radii;
-       -o-border-top-left-radius: $radii;
           border-top-left-radius: $radii;
 }
 
@@ -19,8 +15,6 @@
   -webkit-border-top-right-radius: $radii;
      -moz-border-top-right-radius: $radii;
       -moz-border-radius-topright: $radii;
-      -ms-border-top-right-radius: $radii;
-       -o-border-top-right-radius: $radii;
           border-top-right-radius: $radii;
 }
 
@@ -28,8 +22,6 @@
   -webkit-border-bottom-left-radius: $radii;
      -moz-border-bottom-left-radius: $radii;
       -moz-border-radius-bottomleft: $radii;
-      -ms-border-bottom-left-radius: $radii;
-       -o-border-bottom-left-radius: $radii;
           border-bottom-left-radius: $radii;
 }
 
@@ -37,8 +29,6 @@
   -webkit-border-bottom-right-radius: $radii;
      -moz-border-bottom-right-radius: $radii;
       -moz-border-radius-bottomright: $radii;
-      -ms-border-bottom-right-radius: $radii;
-       -o-border-bottom-right-radius: $radii;
           border-bottom-right-radius: $radii;
 }
 


### PR DESCRIPTION
Both IE and Opera support the prefix-less border-radius definition. 

Reference:
http://my.opera.com/community/forums/topic.dml?id=651612
http://stackoverflow.com/questions/635851/support-for-border-radius-in-ie
