### PR TITLE
Change sentence order

### DIFF
--- a/lib/bourbon/sass_extensions/functions/compact.rb
+++ b/lib/bourbon/sass_extensions/functions/compact.rb
@@ -4,8 +4,8 @@ module Bourbon::SassExtensions::Functions::Compact
   def compact(*args)
     sep = :comma
     if args.size == 1 && args.first.is_a?(Sass::Script::List)
-      args = args.first.value
       sep = args.first.separator
+      args = args.first.value
     end
     Sass::Script::List.new(args.reject{|a| !a.to_bool}, sep)
   end


### PR DESCRIPTION
Otherwise we are overriding the `args` variable and couldn't properly extract the `separator`.
