### PR TITLE
Vendor-prefixed *transition-property* names

### DIFF
--- a/app/assets/stylesheets/_bourbon.scss
+++ b/app/assets/stylesheets/_bourbon.scss
@@ -7,6 +7,7 @@
 @import "functions/radial-gradient";
 @import "functions/render-gradients";
 @import "functions/tint-shade";
+@import "functions/transition_propery_name";
 
 // CSS3 Mixins
 @import "css3/animation";

--- a/app/assets/stylesheets/css3/_transition.scss
+++ b/app/assets/stylesheets/css3/_transition.scss
@@ -30,11 +30,11 @@
     $full: compact($prop-1, $prop-2, $prop-3, $prop-4, $prop-5,
                    $prop-6, $prop-7, $prop-8, $prop-9);
 
-  -webkit-transition-property: $full;
-     -moz-transition-property: $full;
-      -ms-transition-property: $full;
-       -o-transition-property: $full;
-          transition-property: $full;
+   -webkit-transition-property: transition-property-names($full, 'webkit');
+      -moz-transition-property: transition-property-names($full, 'moz');
+       -ms-transition-property: transition-property-names($full, 'ms');
+        -o-transition-property: transition-property-names($full, 'o');
+           transition-property: transition-property-names($full, false);
 }
 
 @mixin transition-duration ($time-1: 0,

--- a/app/assets/stylesheets/functions/_transition_propery_name.scss
+++ b/app/assets/stylesheets/functions/_transition_propery_name.scss
@@ -1,0 +1,22 @@
+// Return vendor-prefixed property names if appropriate
+// Example: transition-property-names((transform, color, background), moz) -> -moz-transform, color, background
+//************************************************************************//
+@function transition-property-names($props, $vendor: false) {
+	$new-props: ();
+	
+	@each $prop in $props {
+		$new-props: append($new-props, transition-property-name($prop, $vendor), comma);
+	}
+
+	@return $new-props;
+}
+
+@function transition-property-name($prop, $vendor: false) {
+	// put other properties that need to be prefixed here aswell
+	@if $vendor and $prop == transform {
+		@return unquote('-'+$vendor+'-'+$prop);
+	}
+	@else {
+		@return $prop;
+	}
+}


### PR DESCRIPTION
A Solution for issue #77:

Added a helper function to vendor-prefix _transition-property_ names.

The _transition-property_ mixin now replaces the _transform_ property name with appropriate vendor prefixed variants.

No solution for the shorthand _transition_ mixin yet, though. I think this would require string replacement, which seems not to be possible without going to ruby, if I’m seeing it right.
