### PR TITLE
Minor typo in radial-gradient-function area of docs

### DIFF
--- a/_includes/radial-gradient-function.html
+++ b/_includes/radial-gradient-function.html
@@ -3,7 +3,7 @@
   <p>Outputs a radial-gradient. Use in conjunction with the <a href="#background-image">background-image mixin.</a> The function takes the same arguments as the <a href="#radial-gradient">radial-gradient mixin</a>.</p>
 
 {% highlight scss %}
-@include backgorund-image( radial-gradient(#1e5799, #3dc3d1) );
+@include background-image( radial-gradient(#1e5799, #3dc3d1) );
 @include background-image( radial-gradient(50% 50%, circle cover, #1e5799, #3dc3d1) );
 @include background-image( radial-gradient(50% 50%, circle cover, #eee 10%, #1e5799 30%, #efefef) );
 {% endhighlight %}


### PR DESCRIPTION
If GitHub didn't make it so easy to make this change I might not have even bothered, it's that inconsequential.
