### PR TITLE
Add @font-face mixin to addons

### DIFF
--- a/app/assets/stylesheets/_bourbon.scss
+++ b/app/assets/stylesheets/_bourbon.scss
@@ -29,6 +29,7 @@
 // Addons & other mixins
 @import "addons/button";
 @import "addons/clearfix";
+@import "addons/font-face";
 @import "addons/font-family";
 @import "addons/hide-text";
 @import "addons/html5-input-types";

--- a/app/assets/stylesheets/addons/_font-face.scss
+++ b/app/assets/stylesheets/addons/_font-face.scss
@@ -1,0 +1,12 @@
+@mixin font-face($font-family, $file-path, $weight: normal, $style: normal ) {
+  @font-face {
+      font-family: $font-family;
+      src: url('#{$file-path}.eot');
+      src: url('#{$file-path}.eot?#iefix') format('embedded-opentype'),
+           url('#{$file-path}.woff') format('woff'),
+           url('#{$file-path}.ttf') format('truetype'),
+           url('#{$file-path}.svg##{$font-family}') format('svg');
+      font-weight: $weight;
+      font-style: $style;
+  }
+}


### PR DESCRIPTION
A simple @font-face mixin allowing easier custom fonts integration, like so :

``` scss
@include font-face(nobile, '/fonts/nobile');
@include font-face(nobile, '/fonts/nobile_bold', bold);
@include font-face(nobile, '/fonts/nobile_italic', normal, italic);
```

The mixin itself goes like this :

``` scss
@mixin font-face($font-family, $file-path, $weight: normal, $style: normal ) {
  @font-face {
      font-family: $font-family;
      src: url('#{$file-path}.eot');
      src: url('#{$file-path}.eot?#iefix') format('embedded-opentype'),
           url('#{$file-path}.woff') format('woff'),
           url('#{$file-path}.ttf') format('truetype'),
           url('#{$file-path}.svg##{$font-family}') format('svg');
      font-weight: $weight;
      font-style: $style;
  }
}
```
