### PR TITLE
Removed -moz-border-radius and -mox-box-shadow as Firefox 3.6 reached EOL.

### DIFF
--- a/app/assets/stylesheets/css3/_border-radius.scss
+++ b/app/assets/stylesheets/css3/_border-radius.scss
@@ -1,34 +1,25 @@
 @mixin border-radius ($radii) {
   -webkit-border-radius: $radii;
-     -moz-border-radius: $radii;
           border-radius: $radii;
 }
 
 @mixin border-top-left-radius($radii) {
   -webkit-border-top-left-radius: $radii;
-     -moz-border-top-left-radius: $radii;
-      -moz-border-radius-topleft: $radii;
           border-top-left-radius: $radii;
 }
 
 @mixin border-top-right-radius($radii) {
   -webkit-border-top-right-radius: $radii;
-     -moz-border-top-right-radius: $radii;
-      -moz-border-radius-topright: $radii;
           border-top-right-radius: $radii;
 }
 
 @mixin border-bottom-left-radius($radii) {
   -webkit-border-bottom-left-radius: $radii;
-     -moz-border-bottom-left-radius: $radii;
-      -moz-border-radius-bottomleft: $radii;
           border-bottom-left-radius: $radii;
 }
 
 @mixin border-bottom-right-radius($radii) {
   -webkit-border-bottom-right-radius: $radii;
-     -moz-border-bottom-right-radius: $radii;
-      -moz-border-radius-bottomright: $radii;
           border-bottom-right-radius: $radii;
 }
 

--- a/app/assets/stylesheets/css3/_box-shadow.scss
+++ b/app/assets/stylesheets/css3/_box-shadow.scss
@@ -9,6 +9,5 @@
                    $shadow-5, $shadow-6, $shadow-7, $shadow-8, $shadow-9);
 
   -webkit-box-shadow: $full;
-     -moz-box-shadow: $full;
           box-shadow: $full;
 }


### PR DESCRIPTION
Yay for the gradual death of vendor prefixes.

Here is Mozilla's official announcement, https://blog.mozilla.org/futurereleases/2012/03/23/upcoming-firefox-support-changes/
