### PR TITLE
Update hide-text mixin to use a simpler technique with better performance.

### DIFF
--- a/app/assets/stylesheets/addons/_hide-text.scss
+++ b/app/assets/stylesheets/addons/_hide-text.scss
@@ -1,12 +1,12 @@
 @mixin hide-text {
-  background-color: transparent;
-  border:           0;
-  color:            transparent;
-  font:             0/0 a;
-  text-shadow:      none;
+  text-indent: -9999px;
+  overflow: hidden;
 }
 
-// A CSS image replacement method that does not require the use of text-indent.
+// A CSS image replacement method that fixes the problems with using text-indent
+// http://www.css-101.org/articles/image-replacement/the_new_new_image-replacement_techniques.php
+// Summary: Developers dropped overflow: hidden; from original Phark method for IE5 support.
+//          Adding it back in solves performance problem with drawing a large off-screen box.
 //
 // Examples
 //


### PR DESCRIPTION
Based on the following article I'm recommending a change to the Phark image replacement technique:
http://www.css-101.org/articles/image-replacement/the_new_new_image-replacement_techniques.php

Most people are familiar with using <code>text-indent: -9999px;</code> but this practice has been called into question because it draws a 9999px wide box that extends off screen, which can adversely affect performance. By going back to the original method which includes <code>overflow: hidden;</code> we can avoid the performance hit by preventing the box from being drawn at a size larger than the visible area of the element in question.

The article does a great job of summarizing the pros and cons of the various methods available.
