### PR TITLE
Mixin for image-rendering

### DIFF
--- a/app/assets/stylesheets/_bourbon.scss
+++ b/app/assets/stylesheets/_bourbon.scss
@@ -20,6 +20,7 @@
 @import "css3/box-sizing";
 @import "css3/columns";
 @import "css3/flex-box";
+@import "css3/image-rendering";
 @import "css3/inline-block";
 @import "css3/linear-gradient";
 @import "css3/prefixer";

--- a/app/assets/stylesheets/css3/_image-rendering.css
+++ b/app/assets/stylesheets/css3/_image-rendering.css
@@ -1,0 +1,17 @@
+@mixin image-rendering ($mode:optimizeQuality) {
+
+  @if ($mode == optimizeQuality) or ($mode == bicubic) or ($mode == bilinear) {
+      image-rendering: optimizeQuality; // Gecko, Presto, Webkit
+      -ms-interpolation-mode: bicubic;
+  }
+
+  @else if ($mode == optimizeSpeed) or ($mode == nearest-neighbor) or ($mode == optimize-contrast) or ($mode == crisp-edges) {
+      image-rendering: optimizeSpeed; // Old versions of Firefox/Gecko, Safari when optimize-contrast not supported
+      image-rendering: -moz-crisp-edges; // Gecko in Firefox 6+
+      image-rendering: -o-crisp-edges;
+      image-rendering: -webkit-optimize-contrast; // Safari/Webkit nightlies
+      -ms-interpolation-mode: nearest-neighbor;
+      image-rendering: optimize-contrast; // As per spec
+  }
+
+}


### PR DESCRIPTION
This commit adds a mixin for including `image-rendering` properties and values. The [MDN article](https://developer.mozilla.org/en/CSS/image-rendering) was my core reference for this mixin.

By default, all browsers use bilinear/bicubic image scaling. An additional property value has emerged that allows using the nearest-neighbor algorithm instead, almost specifically for preserving sharp edges in pixel art. The mixin mainly assists in specifying the different names each vendor has chosen for the nearest-neighbor algorithm.

MSIE uses the name `-ms-interpolation-mode` instead of `image-rendering`. This may or may not fall under your exclusion of Internet Explorer filters.

You can pass `optimizeQuality`, `bicubic`, `bilinear`, or nothing to `image-rendering()` to specify that you want the default algorithms. You can pass `optimizeSpeed`, `nearest-neighbor`, `optimize-contrast`, or `crisp-edges` to request nearest-neighbor algorithm.

Safari actually has a third, strange algorithm for `optimizeSpeed` which is being replaced in the Webkit nighties by nearest-neighbor. The mixin assumes that if you are requesting the new nearest-neightbor algorithm where implemented if you specify `optimizeSpeed`.
