### PR TITLE
Use Thor for command parsing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,9 @@
 PATH
   remote: .
   specs:
-    bourbon (1.4.0)
+    bourbon (2.1.1)
       sass (>= 3.1)
+      thor
 
 GEM
   remote: http://rubygems.org/
@@ -35,8 +36,9 @@ GEM
     rspec-expectations (2.8.0)
       diff-lcs (~> 1.1.2)
     rspec-mocks (2.8.0)
-    sass (3.1.15)
+    sass (3.2.1)
     term-ansicolor (1.0.7)
+    thor (0.15.4)
 
 PLATFORMS
   ruby

--- a/bin/bourbon
+++ b/bin/bourbon
@@ -2,4 +2,4 @@
 
 require "bourbon"
 
-Bourbon::Generator.new(ARGV).run
+Bourbon::Generator.start

--- a/bourbon.gemspec
+++ b/bourbon.gemspec
@@ -27,6 +27,7 @@ that support only CSS3 prefixed properties.
   s.require_paths = ["lib"]
 
   s.add_dependency('sass', '>= 3.1')
+  s.add_dependency('thor')
 
   s.add_development_dependency('aruba', '~> 0.4')
   s.add_development_dependency('rake')

--- a/lib/bourbon/generator.rb
+++ b/lib/bourbon/generator.rb
@@ -1,19 +1,19 @@
 require "fileutils"
+require 'thor'
 
 module Bourbon
-  class Generator
-    def initialize(arguments)
-      @subcommand = arguments.first
-    end
-
-    def run
-      if @subcommand == "install"
-       install
-      elsif @subcommand == "update"
-        update
+  class Generator < Thor
+    desc 'install', 'Install Bourbon into your project'
+    def install
+      if bourbon_files_already_exist?
+        puts "Bourbon files already installed, doing nothing."
+      else
+        install_files
+        puts "Bourbon files installed to bourbon/"
       end
     end
 
+    desc 'update', 'Update Bourbon'
     def update
       if bourbon_files_already_exist?
         remove_bourbon_directory
@@ -21,15 +21,6 @@ module Bourbon
         puts "Bourbon files updated."
       else
         puts "No existing bourbon installation. Doing nothing."
-      end
-    end
-
-    def install
-      if bourbon_files_already_exist?
-        puts "Bourbon files already installed, doing nothing."
-      else
-        install_files
-        puts "Bourbon files installed to bourbon/"
       end
     end
 


### PR DESCRIPTION
An internal change: use a proper argument parser instead of a quick hack. This is to pave the way for things like `bourbon install neat` and `bourbon plugin generate`, plus things like `bourbon install --verbose`. So far this simple change only gives us `--help`.
