### PR TITLE
Font-face inclusion order

### DIFF
--- a/app/assets/stylesheets/css3/_font-face.scss
+++ b/app/assets/stylesheets/css3/_font-face.scss
@@ -1,3 +1,5 @@
+// Order of the includes matters, and it is: normal, bold, italic, bold+italic.
+
 @mixin font-face($font-family, $file-path, $weight: normal, $style: normal, $asset-pipeline: false ) {
   @font-face {
     font-family: $font-family;


### PR DESCRIPTION
IE has problems if you don't import webfonts for different font-weights in a particular order.
See https://github.com/thoughtbot/bourbon/issues/110
