### PR TITLE
Add @arrow mixin for addons

### DIFF
--- a/app/assets/stylesheets/_bourbon.scss
+++ b/app/assets/stylesheets/_bourbon.scss
@@ -34,6 +34,7 @@
 @import "css3/user-select";
 
 // Addons & other mixins
+@import "addons/arrow";
 @import "addons/button";
 @import "addons/clearfix";
 @import "addons/font-family";

--- a/app/assets/stylesheets/addons/_arrow.scss
+++ b/app/assets/stylesheets/addons/_arrow.scss
@@ -1,0 +1,22 @@
+@mixin arrow($direction, $h, $a, $b, $color) {
+  $a-dir: bottom;
+  $b-dir: top;
+  @if $direction == left or $direction == right {
+    $a-dir: bottom;
+    $b-dir: top;
+  }
+  @if $direction == top or $direction == bottom {
+    $a-dir: left;
+    $b-dir: right;
+  }
+
+  border-#{$a-dir}: $a solid transparent;
+  border-#{$b-dir}: $b solid transparent;
+  border-#{$direction}: $h solid $color;
+  bottom: 0;
+  content: '';
+  height: 0;
+  position: absolute;
+  right: 0;
+  width: 0;
+}


### PR DESCRIPTION
## A simple arrow mixin

``` scss
.pupup:after {
  @include arrow(bottom, 30px, 30px, 30px, gray);
  left: -30px;
  top: 6px;
}
```

![popup3.png](https://f.cloud.github.com/assets/483482/2460/e0be9102-421f-11e2-8013-1345bac00d6f.png)

``` scss
.pupup:before {
  @include arrow(bottom, 30px, 30px, 30px, red);
  left: -30px;
  top: 6px;
}

.pupup:after {
  @include arrow(bottom, 30px, 30px, 30px, white);
  left: -30px;
  top: 6px;
}
```

![popup2.png](https://f.cloud.github.com/assets/483482/2458/3ee99dd6-421f-11e2-8e52-73bf3423f4fd.png)
