### PR TITLE
Fixing calculation of flex-gutter and flex-grid functions

### DIFF
--- a/app/assets/stylesheets/functions/_flex-grid.scss
+++ b/app/assets/stylesheets/functions/_flex-grid.scss
@@ -1,13 +1,13 @@
 // Flexible grid
 @function flex-grid($columns, $container-columns: $fg-max-columns) {
   $width: $columns * $fg-column + ($columns - 1) * $fg-gutter;
-  $container-width: $container-columns * $fg-column + ($container-columns - 1) * $fg-gutter;
+  $container-width: $container-columns * $fg-column + $container-columns * $fg-gutter;
   @return percentage($width / $container-width);
 }
 
 // Flexible gutter
 @function flex-gutter($container-columns: $fg-max-columns, $gutter: $fg-gutter) {
-  $container-width: $container-columns * $fg-column + ($container-columns - 1) * $fg-gutter;
+  $container-width: $container-columns * $fg-column + $container-columns * $fg-gutter;
   @return percentage($gutter / $container-width);
 }
 


### PR DESCRIPTION
After trying to use the `flex-gutter()` and `flex-grid()` functions, I found that the width calculations were wrong. If you take the example in the comments of the [_flex-grid.scss](https://github.com/Emerson/bourbon/blob/master/app/assets/stylesheets/functions/_flex-grid.scss) file and run the numbers manually through the `flex-gutter()` and `flex-grid()` functions, you'll see that the result is incorrect (too big).

To confirm this problem:
- start a new rails app
- install bourbon
-  create a basic 4-column flex layout, using the defaults from the docs or comments in the `_flex-grid.scss` file
- Notice that the columns don't work (they are too big).
