### PR TITLE
Adding stylesheets path to Sass.load_paths for non Rails apps

### DIFF
--- a/lib/bourbon.rb
+++ b/lib/bourbon.rb
@@ -4,6 +4,10 @@ $LOAD_PATH.unshift dir unless $LOAD_PATH.include?(dir)
 
 require "bourbon/generator"
 
+unless defined?(Sass)
+  require 'sass'
+end
+
 module Bourbon
   if defined?(Rails) && defined?(Rails::Engine)
     class Engine < ::Rails::Engine
@@ -17,9 +21,7 @@ module Bourbon
         end
       end
     end
+  else
+    Sass.load_paths << File.expand_path("../../app/assets/stylesheets", __FILE__)
   end
-end
-
-unless defined?(Sass)
-  require 'sass'
 end


### PR DESCRIPTION
Here is a tiny patch that adds Bourbon's stylesheets path to `Sass.load_paths` for non Rails apps to be able to use the stylesheets from the gem, instead of copying and updating them manually into each project.
