### PR TITLE
Add configuration vars for vendor prefix output

### DIFF
--- a/app/assets/stylesheets/addons/_prefixer.scss
+++ b/app/assets/stylesheets/addons/_prefixer.scss
@@ -1,20 +1,25 @@
 //************************************************************************//
 // Example: @include prefixer(border-radius, $radii, webkit ms spec);
 //************************************************************************//
+$experimental-support-for-webkit    : true !default;
+$experimental-support-for-mozilla   : true !default;
+$experimental-support-for-microsoft : true !default;
+$experimental-support-for-opera     : true !default;
+
 @mixin prefixer ($property, $value, $prefixes) {
 
   @each $prefix in $prefixes {
 
-    @if $prefix == webkit {
+    @if $prefix == webkit and $experimental-support-for-webkit == true {
       -webkit-#{$property}: $value;
     }
-    @else if $prefix == moz {
+    @else if $prefix == moz and $experimental-support-for-mozilla == true {
       -moz-#{$property}: $value;
     }
-    @else if $prefix == ms {
+    @else if $prefix == ms and $experimental-support-for-microsoft == true {
       -ms-#{$property}: $value;
     }
-    @else if $prefix == o {
+    @else if $prefix == o and $experimental-support-for-opera == true {
       -o-#{$property}: $value;
     }
     @else if $prefix == spec {


### PR DESCRIPTION
This allows a user to define globally what vendor prefixes will be generated.

A simple use case is if you are building an html iOS app only targeting the
`webkit` browser, you can declare these settings prior to calling any mixins
and tune down the final output. 

The variable naming mirrors what is found in [Compass](https://github.com/chriseppstein/compass/blob/stable/frameworks/compass/stylesheets/compass/_support.scss), which would 
hopefully ease the pain in someone transitioning over to Bourbon.
