### PR TITLE
Selector prefix mixin

### DIFF
--- a/app/assets/stylesheets/addons/_selector-prefix.scss
+++ b/app/assets/stylesheets/addons/_selector-prefix.scss
@@ -1,0 +1,11 @@
+@mixin class-prefix($selector, $property, $value...) {
+  .#{$selector} & {
+    #{$property}: $value;
+  }
+}
+
+@mixin id-prefix($selector, $property, $value...) {
+  ##{$selector} & {
+    #{$property}: $value;
+  }
+}


### PR DESCRIPTION
I have added one file (containing two new mixins) named "_selector-prefix.scss" in the "app/assets/stylesheets/addons" directory.

A wee bit of background: I use the Modernizr (modernizr.com) library, which appends classes to the html element depending on your browser capabilities.  Occasionally, I need to modify styles according to those appended classes.  I have developed these two mixins to abstract that process.

Example SCSS file:

``` scss
.example {
    color: green;

    .child {
        color: blue;

        @include class-prefix(no-js, display, none);
    }
}
```

becomes:

``` css
.example {
    color: green;
}
.example .child {
    color: blue;
}
.no-js .example .child {
    display: none;
}
```

I hope this helps.
- Kevin Weber
