### PR TITLE
Honor $asset-pipeline argument when emitting 1x background-image

### DIFF
--- a/app/assets/stylesheets/addons/_retina-image.scss
+++ b/app/assets/stylesheets/addons/_retina-image.scss
@@ -1,5 +1,10 @@
 @mixin retina-image($filename, $background-size, $extension: png, $retina-filename: null, $asset-pipeline: false) {
-  background-image: url($filename + "." + $extension);
+  @if $asset-pipeline {
+    background-image: image_url($filename + "." + $extension);
+  }
+  @else {
+    background-image: url($filename + "." + $extension);
+  }
 
   @include hidpi {
 


### PR DESCRIPTION
The retina-image mixin was using the `$asset-pipeline` flag inside the hidpi media query, but not in the default case. This meant that in Rails, the 1x background image would have the incorrect URL.
