### PR TITLE
Add rem unit mixin for font-size

### DIFF
--- a/app/assets/stylesheets/css3/_rem.scss
+++ b/app/assets/stylesheets/css3/_rem.scss
@@ -1,6 +1,9 @@
-// This mixin assumes `font-size: 62.5%` on the html or body tag.
-// Doing so gives us a convenient 1rem == 10px relation.
-@mixin rem($font-size) {
+// Convert pixels font-size value to rem while keeping a pixel fallback
+// This mixin assumes the body font-size is the default `100%`
+// If not, you can use the optional $base-size param
+// eg. for a body font-size of `62.5%`, use `@include rem(24, 62.5)`
+
+@mixin rem($font-size, $base-size: 100) {
   font-size: $font-size + px;
-  font-size: $font-size / 10 + rem;
+  font-size: ($font-size / $base-size * 100 / 16) + rem;
 }


### PR DESCRIPTION
This mixin allows easier use of `rem` units when working with font-size. Rem gives user resizable text, just like em units, without the hassle of compounding font-sizes. More info about the advantages of using `rem` over `em` or `px` can be found here: http://snook.ca/archives/html_and_css/font-size-with-rem

As `rem` is not supported by IE8 and lower (http://caniuse.com/#search=rem), we still need to provide a pixel fallback, hence the need for a mixin. The easiest way to work with this is to set `font-size: 62.5%` on the `html` or `body` tag, wich gives us a nice `1rem == 10px` relation to work with.

The usage is:

``` scss
h2 {
  @include rem(18);
}
```

wich outputs:

``` css
h2 {
  font-size: 18px;
  font-size: 1.8rem;
}
```

Let me know what you think!
