### PR TITLE
Hide-text mixin should not override background and border

### DIFF
--- a/app/assets/stylesheets/addons/_hide-text.scss
+++ b/app/assets/stylesheets/addons/_hide-text.scss
@@ -1,6 +1,4 @@
 @mixin hide-text {
-  background-color: transparent;
-  border:           0;
   color:            transparent;
   font:             0/0 a;
   text-shadow:      none;


### PR DESCRIPTION
Hiding the text has nothing necessarily to do with the background or the border.
It could be more useful to let them be override outside of the mixin because it's not always needed when we try to hide the text.
