### PR TITLE
update _retina-image.scss to use correct prefix

### DIFF
--- a/app/assets/stylesheets/addons/_retina-image.scss
+++ b/app/assets/stylesheets/addons/_retina-image.scss
@@ -8,7 +8,7 @@
         background-image: image_url($retina-filename + "." + $extension);
       }
       @else {
-        background-image: image_url($filename + "@2x" + "." + $extension);
+        background-image: image_url($filename + "_2x" + "." + $extension);
       }
     }
 
@@ -17,7 +17,7 @@
         background-image: url($retina-filename + "." + $extension);
       }
       @else {
-        background-image: url($filename + "@2x" + "." + $extension);
+        background-image: url($filename + "_2x" + "." + $extension);
       }
     }
 


### PR DESCRIPTION
as it specifically says in Apples documentation, you shouldn't use the @2x prefix.

> A common file-naming convention for high-resolution images on the web is to prepend _2x >before the file extension; for example, myImage_2x.jpg. Don’t use @2x in the filename, >since the @ character in a URL is reserved as the delimiter separating the username and >password from the host in authentication URL schemes.

[reference](http://developer.apple.com/library/safari/#documentation/NetworkingInternet/Conceptual/SafariImageDeliveryBestPractices/ServingImagestoRetinaDisplays/ServingImagestoRetinaDisplays.html#//apple_ref/doc/uid/TP40012449-CH3-SW1)
