### PR TITLE
Remove flicker in smooth scrolling

### DIFF
--- a/js/smoothscroll.js
+++ b/js/smoothscroll.js
@@ -1,13 +1,25 @@
-$('a[href*=#]:not([href=#])').click(function() {
+$('a[href*=#]:not([href=#])').click(function(event) {
   if (location.pathname.replace(/^\//,'') == this.pathname.replace(/^\//,'') 
     || location.hostname == this.hostname) {
 
-    var target = $(this.hash);
-    target = target.length ? target : $('[name=' + this.hash.slice(1) +']');
-     if (target.length) {
-       $('html,body').animate({
-         scrollTop: target.offset().top
-       }, 1000);
+    var hash = this.hash;
+    var target = $(hash);
+    target = target.length ? target : $('[name=' + hash.slice(1) +']');
+    if (target.length) {
+      event.preventDefault();
+      $('html,body').stop().animate({
+        scrollTop: target.offset().top
+      }, 1000, function() {
+        location.hash = hash;
+      });
     }
+  }
+});
+
+$(window).bind('hashchange', function(event) {
+  var target = $(location.hash);
+  target = target.length ? target : $('[name=' + location.hash.slice(1) +']');
+  if (target.length) {
+    $('html,body').scrollTop(target.offset().top);
   }
 });


### PR DESCRIPTION
I noticed a little flicker when clicking between sections of the documentation. This came from the browser making the immediate jump to the fragment identifier before the `scrollTop` animation had a chance to get started. The changes made to get around the jump:
- If the click meets the condition for smooth scrolling, prevent the default scroll and hashchange.
- Once the smooth scroll is completed, update the `location.hash` to the new fragment.
- Doing the above two messes up the back button functionality a bit (out of step by one history entry), so a `hashchange` event listener is in there to make the right jumps on forward/back.

Thanks as always for the great library.
