### PR TITLE
Adds a global flag around legacy support for IE.

### DIFF
--- a/app/assets/stylesheets/addons/_clearfix.scss
+++ b/app/assets/stylesheets/addons/_clearfix.scss
@@ -11,8 +11,12 @@
 //      }
 //    }
 
+$legacy-for-ie: true !default;
+
 @mixin clearfix {
-  *zoom: 1;
+  @if $legacy-for-ie {
+    *zoom: 1;
+  }
 
   &:before,
   &:after {

--- a/app/assets/stylesheets/css3/_inline-block.scss
+++ b/app/assets/stylesheets/css3/_inline-block.scss
@@ -1,8 +1,13 @@
 // Legacy support for inline-block in IE7 (maybe IE6)
+$legacy-for-ie: true !default;
+
 @mixin inline-block {
   display: inline-block;
   vertical-align: baseline;
-  zoom: 1;
-  *display: inline;
-  *vertical-align: auto;
+
+  @if $legacy-for-ie {
+    zoom: 1;
+    *display: inline;
+    *vertical-align: auto;
+  }
 }


### PR DESCRIPTION
The micro `clearfix` and `inline-block` mixins contain some pretty handy fixes for IE 8 and less, but not really needed in modern browsers. This pull request just adds a global flag whether to output the IE hacks or not. This can drastically cut down on the CSS output within a project. 

While it'd be great to fully remove these hacks, I believe, having them remain available is way too useful still.
