### PR TITLE
Improve font-face rendering for Chrome on Windows

### DIFF
--- a/app/assets/stylesheets/css3/_font-face.scss
+++ b/app/assets/stylesheets/css3/_font-face.scss
@@ -20,4 +20,18 @@
            url('#{$file-path}.svg##{$font-family}')      format('svg');
     }
   }
+  
+  @media screen and (-webkit-min-device-pixel-ratio: 0) {
+    @font-face {
+      font-family: $font-family;
+      font-weight: $weight;
+      font-style: $style;
+
+      @if $asset-pipeline == true {
+        src: font-url('#{$file-path}.svg')                format('svg');
+      } @else {
+        src: url('#{$file-path}.svg')                     format('svg');
+      }
+    }
+  }
 }


### PR DESCRIPTION
A thorough explanation of the problem and the fix can be found here: http://www.adtrak.co.uk/blog/font-face-chrome-rendering/

I'd understand if you don't want to add this to your library since it's a hack.  But it works great in my projects, so I thought I'd suggest it.  
