### PR TITLE
Documenting the path option

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -56,6 +56,10 @@ Install Bourbon into the current directory by generating the `bourbon` folder:
 
 The generated folder will contain all the mixins and other necessary Bourbon files. It is recommended not to add or modify the Bourbon files so that you can update Bourbon easily.
 
+You can specify a target directory using the `path` option:
+
+    bourbon install --path=my/custom/path/
+
 #### Import
 
 Lastly, import the mixins at the beginning of your stylesheet(s):


### PR DESCRIPTION
When using Bourbon with e.g. Middleman or Jekyll I find myself always moving the installed files after installation manually. So I took a look at the source and discovered that I can specify a destination path as well when running the install task.

Since the target “audience” might contain many front–end devs and maybe even designers who aren’t (very) familiar with Thor and Ruby I figured this could be documented in the Readme.  
