### PR TITLE
Improved position addon

### DIFF
--- a/app/assets/stylesheets/addons/_position.scss
+++ b/app/assets/stylesheets/addons/_position.scss
@@ -1,4 +1,4 @@
-@mixin position ($position: relative, $coordinates: auto auto auto auto, $t: auto, $r: auto, $b: auto, $l: auto) {
+@mixin position ($position: relative, $coordinates: n n n n) {
   // named variables for coordinates will take priority over the list
 
   @if type-of($position) == list {
@@ -8,54 +8,42 @@
 
   position: $position;
 
-  // TOP
-  // First, set $top to the coordinate value.
-  $coordinate-top: nth($coordinates, 1);
-  $top: $coordinate-top;
-  // Override it with the named variable, if there is a named variable defined.
-  @if $t != auto {
-    $top: $t;
-  }
-  // Ignore "auto" and "a" (handy abbreviation for coordinates), since "auto" is the default.
-  @if $top != a and $top != auto {
-    // Translate unitless zeros and numbers with units into a rule.
+  $top: nth($coordinates, 1);
+  $right: nth($coordinates, 2);
+  $bottom: nth($coordinates, 3);
+  $left: nth($coordinates, 4);
+
+  @if $top != n {
+    @if $top == a or $top == auto {
+      top: auto;
+    }
     @if $top == 0 or not(unitless($top)) {
       top: $top;
     }
   }
-  // Do the same for the other coordinates ...
 
-  // RIGHT
-  $coordinate-right: nth($coordinates, 2);
-  $right: $coordinate-right;
-  @if $r != auto {
-    $right: $r;
-  }
-  @if $right != a and $right != auto {
+  @if $right != n {
+    @if $right == a or $right == auto {
+      right: auto;
+    }
     @if $right == 0 or not(unitless($right)) {
       right: $right;
     }
   }
 
-  // BOTTOM
-  $coordinate-bottom: nth($coordinates, 3);
-  $bottom: $coordinate-bottom;
-  @if $b != auto {
-    $bottom: $b;
-  }
-  @if $bottom != a and $bottom != auto {
+  @if $bottom != n {
+    @if $bottom == a or $bottom == auto {
+      bottom: auto;
+    }
     @if $bottom == 0 or not(unitless($bottom)) {
       bottom: $bottom;
     }
   }
 
-  // left
-  $coordinate-left: nth($coordinates, 4);
-  $left: $coordinate-left;
-  @if $l != auto {
-    $left: $l;
-  }
-  @if $left != a and $left != auto {
+  @if $left != n {
+    @if $left == a or $left == auto {
+      left: auto;
+    }
     @if $left == 0 or not(unitless($left)) {
       left: $left;
     }

--- a/logfile
+++ b/logfile
@@ -1,0 +1,7 @@
+LOG:  database system was shut down at 2013-04-30 21:42:02 MST
+LOG:  database system is ready to accept connections
+LOG:  autovacuum launcher started
+LOG:  received smart shutdown request
+LOG:  autovacuum launcher shutting down
+LOG:  shutting down
+LOG:  database system is shut down


### PR DESCRIPTION
I thought of some ways to improve the position addon. The code I wrote into _position.scss should allow the users to do the following:
- Define coordinates as _either_ a coordinate list (as was already the case) _or_ named variables -- `$t, $r, $b, $l` (you may want to write out those words, depending on your style). I've found this to be useful since I usually only want to declare a couple of coordinates, don't need to declare all four.
- Currently, a unitless zero is ignored -- but I find unitless zeroes handy, so I let them pass.
- Instead, `auto` is ignored -- and a shortcut `a` (which I thought would be useful when plugging in coordinates -- e.g. `5px a 15px a` -- if you don't want to use named variables). My reasoning was that `auto` is the default, so we don't need to create that rule. (But what if the value is already defined and I want to _change_ it to `auto`? I think this addon is most useful for an initial declaration, combining position and coordinates. If I just want to change coordinates on an existing position, I will probably change the specific coordinate rule, right?)

Instead of keeping this to myself, I thought I'd hand it back to you. What do you think?
