### PR TITLE
Update _clearfix.scss to use 'nano' clearfix

### DIFF
--- a/app/assets/stylesheets/addons/_clearfix.scss
+++ b/app/assets/stylesheets/addons/_clearfix.scss
@@ -12,9 +12,11 @@
 //    }
 
 @mixin clearfix {
-  content:"";
-  display:table;
-  clear:both;
+  &:after {
+    content:"";
+    display:table;
+    clear:both;
+  }
 }
 
 // Acknowledgements


### PR DESCRIPTION
Use a more modern _three line_ clearfix based on Nicolas Gallagher's 2011 micro clearfix, as announced and explained by Thierry Koblentz [here](http://www.css-101.org/articles/clearfix/latest-new-clearfix-so-far.php)

This is used by [Inuit.css](https://github.com/csswizardry/inuit.css/pull/133), which is a massively popular framework [used by huge projects such as BSkyB](https://github.com/csswizardry/inuit.css#as-used-by) - it's certified legit.

As well as being tiny, it's also less hacky, freeing up the `:before` element for styling.
