### PR TITLE
Using "image-url" instead "image_url" to prevent wrong image paths

### DIFF
--- a/app/assets/stylesheets/addons/_retina-image.scss
+++ b/app/assets/stylesheets/addons/_retina-image.scss
@@ -1,6 +1,6 @@
 @mixin retina-image($filename, $background-size, $extension: png, $retina-filename: null, $asset-pipeline: false) {
   @if $asset-pipeline {
-    background-image: image_url($filename + "." + $extension);
+    background-image: image-url($filename + "." + $extension);
   }
   @else {
     background-image: url($filename + "." + $extension);
@@ -10,10 +10,10 @@
 
     @if $asset-pipeline {
       @if $retina-filename {
-        background-image: image_url($retina-filename + "." + $extension);
+        background-image: image-url($retina-filename + "." + $extension);
       }
       @else {
-        background-image: image_url($filename + "@2x" + "." + $extension);
+        background-image: image-url($filename + "@2x" + "." + $extension);
       }
     }
 


### PR DESCRIPTION
On a rails 4 app having "config.assets.digest = true". The "image_url" on the mixin outputs the css asset name without the fingerprinted names. And that makes the image does not appear.
