### PR TITLE
Add hyphens mixin

### DIFF
--- a/app/assets/stylesheets/_bourbon.scss
+++ b/app/assets/stylesheets/_bourbon.scss
@@ -30,6 +30,7 @@
 @import "css3/columns";
 @import "css3/flex-box";
 @import "css3/font-face";
+@import "css3/hyphens";
 @import "css3/hidpi-media-query";
 @import "css3/image-rendering";
 @import "css3/inline-block";

--- a/app/assets/stylesheets/css3/_hyphens.scss
+++ b/app/assets/stylesheets/css3/_hyphens.scss
@@ -1,0 +1,4 @@
+@mixin hyphens($hyphenation: none) {
+// none | manual | auto
+  @include prefixer(hyphens, $hyphenation, webkit moz ms spec);
+}


### PR DESCRIPTION
Nothing much to say here: it's a mixin for CSS hyphenation!

The hyphens property is not supported in Chrome yet, but it's supported in Firefox, Safari and even IE10. I guess Chrome and Opera will follow soon enough.

Docs here: https://developer.mozilla.org/en-US/docs/Web/CSS/hyphens
Live example: https://developer.mozilla.org/samples/cssref/hyphens.html
