### PR TITLE
Rails 4 font-face path fix

### DIFF
--- a/app/assets/stylesheets/css3/_font-face.scss
+++ b/app/assets/stylesheets/css3/_font-face.scss
@@ -7,11 +7,11 @@
     font-style: $style;
 
     @if $asset-pipeline == true {
-      src: font-url('#{$file-path}.eot');
-      src: font-url('#{$file-path}.eot?#iefix')          format('embedded-opentype'),
-           font-url('#{$file-path}.woff')                format('woff'),
-           font-url('#{$file-path}.ttf')                 format('truetype'),
-           font-url('#{$file-path}.svg##{$font-family}') format('svg');
+      src: url(font-path('#{$file-path}.eot'));
+      src: url(font-path('#{$file-path}.eot?#iefix'))          format('embedded-opentype'),
+           url(font-path('#{$file-path}.woff'))                format('woff'),
+           url(font-path('#{$file-path}.ttf'))                 format('truetype'),
+           url(font-path('#{$file-path}.svg##{$font-family}')) format('svg');
     } @else {
       src: url('#{$file-path}.eot');
       src: url('#{$file-path}.eot?#iefix')               format('embedded-opentype'),


### PR DESCRIPTION
With Rails 4 (or perhaps the latest version of sprockets/sass-rails) the font-url sass helper no longer works correctly: given an app/assets/fonts directory with fonts, font-url would return the correct path in Rails 3. In Rails 4, it does not. This change uses the font-path helper, which seems to return the correct path.

Addresses issue thoughtbot/bourbon#239

~ Jonathan
