### PR TITLE
changed button text size from fixed to inherit

### DIFF
--- a/app/assets/stylesheets/addons/_button.scss
+++ b/app/assets/stylesheets/addons/_button.scss
@@ -68,7 +68,7 @@
   box-shadow: inset 0 1px 0 0 $inset-shadow;
   color: $color;
   display: inline-block;
-  font-size: 11px;
+  font-size: inherit;
   font-weight: bold;
   @include linear-gradient ($base-color, $stop-gradient);
   padding: 7px 18px;
@@ -140,7 +140,7 @@
   box-shadow: inset 0 1px 0 0 $inset-shadow;
   color: $color;
   display: inline-block;
-  font-size: 14px;
+  font-size: inherit;
   font-weight: bold;
   @include linear-gradient(top, $base-color 0%, $second-stop 50%, $third-stop 50%, $fourth-stop 100%);
   padding: 8px 20px;
@@ -211,7 +211,7 @@
   box-shadow: inset 0 1px 0 0 $inset-shadow, 0 1px 2px 0 #b3b3b3;
   color: $color;
   display: inline-block;
-  font-size: 11px;
+  font-size: inherit;
   font-weight: normal;
   line-height: 1;
   @include linear-gradient ($base-color, $stop-gradient);


### PR DESCRIPTION
the three button types had fixed font sizes of 11px, 14px, and 11px respectively. i find myself overriding them whenever present. i changed the values to 'inherit' so they match surrounding text, and can be overridden more easily.
