### PR TITLE
added "input:not([type])" to list of "text-based inputs".

### DIFF
--- a/app/assets/stylesheets/addons/_html5-input-types.scss
+++ b/app/assets/stylesheets/addons/_html5-input-types.scss
@@ -21,7 +21,7 @@ $inputs-list: 'input[type="email"]',
               'input[type="week"]',
               
               // includes inputs with no type attribute (i.e., <input>)
-              input:not( [type] );
+              'input:not( [type] )';
 
 $unquoted-inputs-list: ();
 @each $input-type in $inputs-list {


### PR DESCRIPTION
Inputs with no type attribute (e.g., `<input>`) are semantically and functionally identical to the `text` type, but are unfortunately difficult to style via CSS. `input:not([type])` works in IE9+, and is the simplest, most encompassing solution I have found.
