### PR TITLE
Add Roboto to the `$helvetica` font stack for Android support

### DIFF
--- a/app/assets/stylesheets/addons/_font-family.scss
+++ b/app/assets/stylesheets/addons/_font-family.scss
@@ -1,5 +1,5 @@
 $georgia: Georgia, Cambria, "Times New Roman", Times, serif;
-$helvetica: "Helvetica Neue", Helvetica, Arial, sans-serif;
+$helvetica: "Helvetica Neue", Helvetica, Roboto, Arial, sans-serif;
 $lucida-grande: "Lucida Grande", Tahoma, Verdana, Arial, sans-serif;
 $monospace: "Bitstream Vera Sans Mono", Consolas, Courier, monospace;
 $verdana: Verdana, Geneva, sans-serif;


### PR DESCRIPTION
Most Android devices do not have either Helvetica Neue or Helvetica available, but as of Android 4.0 "Ice Cream Sandwich" there is a look-alike font called Roboto that serves as a decent stand-in for the (better) Helvetica fonts.
