### PR TITLE
Updated hide-text mixin to comply with the new h5bp approach

### DIFF
--- a/app/assets/stylesheets/addons/_hide-text.scss
+++ b/app/assets/stylesheets/addons/_hide-text.scss
@@ -1,5 +1,10 @@
 @mixin hide-text {
-  color:            transparent;
-  font:             0/0 a;
-  text-shadow:      none;
+  overflow: hidden;
+
+  &:before {
+    content: "";
+    display: block;
+    width: 0;
+    height: 100%;
+  }
 }


### PR DESCRIPTION
h5bp documentation: https://github.com/h5bp/html5-boilerplate/commit/adecc5da035d6d76b77e3fa95c6abde841073da2

I removed the IE6/7 hack and the background-color and border resets
