### PR TITLE
Add !global to html5 input loops to remove deprecation notices with Sass 3.3rc

### DIFF
--- a/app/assets/stylesheets/addons/_html5-input-types.scss
+++ b/app/assets/stylesheets/addons/_html5-input-types.scss
@@ -22,7 +22,7 @@ $inputs-list: 'input[type="email"]',
 
 $unquoted-inputs-list: ();
 @each $input-type in $inputs-list {
-  $unquoted-inputs-list: append($unquoted-inputs-list, unquote($input-type), comma);
+  $unquoted-inputs-list: append($unquoted-inputs-list, unquote($input-type), comma) !global;
 }
 
 $all-text-inputs: $unquoted-inputs-list;
@@ -33,7 +33,7 @@ $all-text-inputs: $unquoted-inputs-list;
 $all-text-inputs-hover: ();
 @each $input-type in $unquoted-inputs-list {
       $input-type-hover: $input-type + ":hover";
-      $all-text-inputs-hover: append($all-text-inputs-hover, $input-type-hover, comma);
+      $all-text-inputs-hover: append($all-text-inputs-hover, $input-type-hover, comma) !global;
 }
 
 // Focus Pseudo-class
@@ -41,7 +41,7 @@ $all-text-inputs-hover: ();
 $all-text-inputs-focus: ();
 @each $input-type in $unquoted-inputs-list {
       $input-type-focus: $input-type + ":focus";
-      $all-text-inputs-focus: append($all-text-inputs-focus, $input-type-focus, comma);
+      $all-text-inputs-focus: append($all-text-inputs-focus, $input-type-focus, comma) !global;
 }
 
 // You must use interpolation on the variable:


### PR DESCRIPTION
This should fix the deprecation notices from #286.

!global variables was implemented just before the release of 3.3rc: https://github.com/nex3/sass/issues/473
A rewrite of how these variables are defined might be necessary at a later point.
