### PR TITLE
Add !global to html5-input-types.scss to remove deprecation warnings in sass-3.3.0.rc.2

### DIFF
--- a/app/assets/stylesheets/addons/_html5-input-types.scss
+++ b/app/assets/stylesheets/addons/_html5-input-types.scss
@@ -67,7 +67,7 @@ $inputs-button-list: 'input[type="button"]',
 
 $unquoted-inputs-button-list: ();
 @each $input-type in $inputs-button-list {
-  $unquoted-inputs-button-list: append($unquoted-inputs-button-list, unquote($input-type), comma);
+  $unquoted-inputs-button-list: append($unquoted-inputs-button-list, unquote($input-type), comma) !global;
 }
 
 $all-button-inputs: $unquoted-inputs-button-list;
@@ -78,7 +78,7 @@ $all-button-inputs: $unquoted-inputs-button-list;
 $all-button-inputs-hover: ();
 @each $input-type in $unquoted-inputs-button-list {
       $input-type-hover: $input-type + ":hover";
-      $all-button-inputs-hover: append($all-button-inputs-hover, $input-type-hover, comma);
+      $all-button-inputs-hover: append($all-button-inputs-hover, $input-type-hover, comma) !global;
 }
 
 // Focus Pseudo-class
@@ -86,7 +86,7 @@ $all-button-inputs-hover: ();
 $all-button-inputs-focus: ();
 @each $input-type in $unquoted-inputs-button-list {
       $input-type-focus: $input-type + ":focus";
-      $all-button-inputs-focus: append($all-button-inputs-focus, $input-type-focus, comma);
+      $all-button-inputs-focus: append($all-button-inputs-focus, $input-type-focus, comma) !global;
 }
 
 // Active Pseudo-class
@@ -94,7 +94,7 @@ $all-button-inputs-focus: ();
 $all-button-inputs-active: ();
 @each $input-type in $unquoted-inputs-button-list {
       $input-type-active: $input-type + ":active";
-      $all-button-inputs-active: append($all-button-inputs-active, $input-type-active, comma);
+      $all-button-inputs-active: append($all-button-inputs-active, $input-type-active, comma) !global;
 }
 
 // You must use interpolation on the variable:


### PR DESCRIPTION
This fixes the deprecation warnings in sass-3.3.0.rc.2.
