### PR TITLE
Explicit size units

### DIFF
--- a/app/assets/stylesheets/addons/_size.scss
+++ b/app/assets/stylesheets/addons/_size.scss
@@ -1,44 +1,16 @@
 @mixin size($size) {
-  @if length($size) == 1 {
-    @if $size == auto {
-      width:  $size;
-      height: $size;
-    }
+  $height: nth($size, 1);
+  $width: $height;
 
-    @else if unitless($size) {
-      width:  $size + px;
-      height: $size + px;
-    }
-
-    @else if not(unitless($size)) {
-      width:  $size;
-      height: $size;
-    }
+  @if length($size) > 1 {
+    $height: nth($size, 2);
   }
 
-  // Width x Height
-  @if length($size) == 2 {
-    $width:  nth($size, 1);
-    $height: nth($size, 2);
+  @if $height == auto or (type-of($height) == number and not unitless($height)) {
+    height: $height;
+  }
 
-    @if $width == auto {
-      width: $width;
-    }
-    @else if not(unitless($width)) {
-      width: $width;
-    }
-    @else if unitless($width) {
-      width: $width + px;
-    }
-
-    @if $height == auto {
-      height: $height;
-    }
-    @else if not(unitless($height)) {
-      height: $height;
-    }
-    @else if unitless($height) {
-      height: $height + px;
-    }
+  @if $width == auto or (type-of($height) == number and not unitless($width)) {
+    width: $width;
   }
 }


### PR DESCRIPTION
In this small PR I make `size` ignore unitless numbers as arguments. In other words `@include size(10);` will have no effect on the resultant CSS.

**Reason?** In CSS numeric widths and heights always have units. They're considered invalid otherwise… Being explicit about units here is good because it doesn't leave much space for imagination - for an instance I initially thought that `@include size(1)` gives a `1em × 1em` square. ;)

Hope you guys like it.
