### PR TITLE
Support font-feature-settings

### DIFF
--- a/app/assets/stylesheets/css3/_font-feature-settings.scss
+++ b/app/assets/stylesheets/css3/_font-feature-settings.scss
@@ -1,0 +1,10 @@
+// Font feature settings mixin and property default.
+// Examples: @include font-feature-settings("liga");
+//           @include font-feature-settings("lnum" false);
+//           @include font-feature-settings("pnum" 1, "kern" 0);
+//           @include font-feature-settings("ss01", "ss02");
+
+@mixin font-feature-settings($settings...) {
+  @if length($settings) == 0 { $settings: none; }
+  @include prefixer(font-feature-settings, $settings, webkit moz ms spec);
+}


### PR DESCRIPTION
Adds a font-feature-settings mixin. I wasn’t sure where Bourbon’s cutoff is for a vendor prefix age, but Firefox 4 has a different syntax for font-feature-settings (`font-feature-settings: "liga=1, pnum=0";`) that could be supported, too.
