### PR TITLE
fixed typo in _modular-scale partial

### DIFF
--- a/app/assets/stylesheets/functions/_modular-scale.scss
+++ b/app/assets/stylesheets/functions/_modular-scale.scss
@@ -1,4 +1,4 @@
-// Scaling Varaibles
+// Scaling Variables
 $golden:           1.618;
 $minor-second:     1.067;
 $major-second:     1.125;


### PR DESCRIPTION
Fixes a tiny typo.
