### PR TITLE
Fixed flat button border

### DIFF
--- a/app/assets/stylesheets/addons/_button.scss
+++ b/app/assets/stylesheets/addons/_button.scss
@@ -293,6 +293,7 @@
 
   background-color: $base-color;
   border-radius: 3px;
+  border: none;
   color: $color;
   display: inline-block;
   font-size: inherit;


### PR DESCRIPTION
Remove borders as browsers add borders to input buttons which breaks the flat look.
