### PR TITLE
Addition of word-wrap: normal; for IE8/9

### DIFF
--- a/dist/addons/_ellipsis.scss
+++ b/dist/addons/_ellipsis.scss
@@ -4,4 +4,5 @@
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+  word-wrap: normal;
 }


### PR DESCRIPTION
Developing an app recently that requires IE8/IE9 compatibility, I noticed that the addition of word-wrap: normal; made this mixin work across the board.
