### PR TITLE
Adds font-feature-settings documentation

### DIFF
--- a/_includes/font-feature-settings.html
+++ b/_includes/font-feature-settings.html
@@ -1,0 +1,13 @@
+<article id="font-feature-settings" data-type="mixin">
+  <h2>Font-feature-settings <a class="view-source" href="https://github.com/thoughtbot/bourbon/blob/master/app/assets/stylesheets/css3/_font-feature-settings.scss">View source</a></h2>
+  <p>The font-feature-settings mixin is helpful for using the advanced typographic features included in some OpenType fonts.</p>
+
+{% highlight scss %}
+// Use ligatures if the typeface and font file include them
+@include font-feature-settings("liga");
+
+// Use proportional numbers, but not automatic kerning
+@include font-feature-settings("pnum", "kern" false);
+{% endhighlight %}
+</article>
+


### PR DESCRIPTION
Forgot to open a PR for this part: basic documentation for #316. I don’t use Jekyll anymore so I didn’t actually manage to get this compiled. If someone else wouldn’t mind doing that, it’d really appreciate it. 

I can also add more examples if you think it’d be appropriate. On the CSS side of things `font-feature-settings`, has some pretty complex possibilities, but the mixin itself is simple.
