### PR TITLE
Conflict with $red, $green, and $blue variable names

### DIFF
--- a/dist/functions/_color-lightness.scss
+++ b/dist/functions/_color-lightness.scss
@@ -3,11 +3,11 @@
 // More details here http://robots.thoughtbot.com/closer-look-color-lightness
 
 @function is-light($hex-color) {
-  $red: red(rgba($hex-color, 1.0));
-  $green: green(rgba($hex-color, 1.0));
-  $blue: blue(rgba($hex-color, 1.0));
+  $-local-red: red(rgba($hex-color, 1.0));
+  $-local-green: green(rgba($hex-color, 1.0));
+  $-local-blue: blue(rgba($hex-color, 1.0));
 
-  $lightness: ($red * 0.2126 + $green * 0.7152 + $blue * 0.0722) / 255;
+  $-local-lightness: ($-local-red * 0.2126 + $-local-green * 0.7152 + $-local-blue * 0.0722) / 255;
 
-  @return $lightness > .6;
+  @return $-local-lightness > .6;
 }


### PR DESCRIPTION
I put together a project using the latest versions of Bourbon, Neat, and Bitters and I'm noticing that color variables with the names `$red`, `$green`, and `$blue` are overwritten by the Bourbon function, `is-light()`.

When I compile the following SASS (3.3.3) file, the color `$blue` is output as `202`, not `#477DCA` as defined in `bitters/_variables.scss`:

``` sass
@import "bourbon/bourbon"; // Bourbon 4.0.0.rc1
@import "neat/neat";       // Neat 1.5.0
@import "bitters/bitters"; // Bitters 0.9.3

body {
  background: $blue;
}
```

It looks like the conflict happens when `@include button(simple, $base-accent-color);` is called in `bitters/_button.scss`. I'm using the default Bitters setup as an example but it looks like this could happen by defining a variable named `$red`, `$green`, or `$blue` outside the main SASS stylesheet.
