### PR TITLE
Add word-wrap mixin

### DIFF
--- a/app/assets/stylesheets/_bourbon.scss
+++ b/app/assets/stylesheets/_bourbon.scss
@@ -71,6 +71,7 @@
 @import "addons/size";
 @import "addons/timing-functions";
 @import "addons/triangle";
+@import "addons/word-wrap";
 
 // Soon to be deprecated Mixins
 @import "bourbon-deprecated-upcoming";

--- a/app/assets/stylesheets/addons/_word-wrap.scss
+++ b/app/assets/stylesheets/addons/_word-wrap.scss
@@ -1,0 +1,8 @@
+@mixin word-wrap($wrap: break-word) {
+  word-wrap: $wrap;
+
+  @if $wrap == break-word {
+    overflow-wrap: break-word;
+    word-break: break-all;
+  }
+}

--- a/dist/_bourbon.scss
+++ b/dist/_bourbon.scss
@@ -71,6 +71,7 @@
 @import "addons/size";
 @import "addons/timing-functions";
 @import "addons/triangle";
+@import "addons/word-wrap";
 
 // Soon to be deprecated Mixins
 @import "bourbon-deprecated-upcoming";

--- a/dist/addons/_word-wrap.scss
+++ b/dist/addons/_word-wrap.scss
@@ -1,0 +1,8 @@
+@mixin word-wrap($wrap: break-word) {
+  word-wrap: $wrap;
+
+  @if $wrap == break-word {
+    overflow-wrap: break-word;
+    word-break: break-all;
+  }
+}


### PR DESCRIPTION
Makes it easy to add "word-wrap: break-word", while also supporting "normal".

This is often combined with "hyphens: auto", but I have left it off since the hyphens addon makes that easy.
