### PR TITLE
Fix directional-property

### DIFF
--- a/app/assets/stylesheets/addons/_directional-values.scss
+++ b/app/assets/stylesheets/addons/_directional-values.scss
@@ -57,9 +57,6 @@
   $right:  $pre + "-right"  + if($suf, "-#{$suf}", "");
   $all:    $pre +             if($suf, "-#{$suf}", "");
 
-  // Get list inside $vals (is there a better way?)
-  @each $val in $vals { $vals: $val; }
-
   $vals: collapse-directionals($vals);
 
   @if contains-falsy($vals) {

--- a/dist/addons/_directional-values.scss
+++ b/dist/addons/_directional-values.scss
@@ -57,9 +57,6 @@
   $right:  $pre + "-right"  + if($suf, "-#{$suf}", "");
   $all:    $pre +             if($suf, "-#{$suf}", "");
 
-  // Get list inside $vals (is there a better way?)
-  @each $val in $vals { $vals: $val; }
-
   $vals: collapse-directionals($vals);
 
   @if contains-falsy($vals) {


### PR DESCRIPTION
An unnecessary loop was overwriting the $vals argument, outputting only
the last value. This change does not effect mixins that use
directional-property.
