### PR TITLE
Create makefile with rsync for dist folder

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+dist:
+	rsync -avv app/assets/stylesheets/ dist/


### PR DESCRIPTION
I just threw together this quick makefile with rsync for `app/assets/stylesheets/ => dist/`, after talking to @plapier about some bower stuff. Hopefully it'll [_make_](http://i.imgur.com/xgO5PG4.gif) it a bit easier to keep the two folders in sync.

---

**Changes:**
- Created `Makefile` with one way `rsync` from `app/assets/stylesheets` to `dist/`

---

Let me know if you need anything else
