### PR TITLE
4.0.0.rc2 - Fix issue with position mixin that causes 0 to not return null

### DIFF
--- a/app/assets/stylesheets/addons/_position.scss
+++ b/app/assets/stylesheets/addons/_position.scss
@@ -1,32 +1,17 @@
 @mixin position ($position: relative, $coordinates: null null null null) {
-
   @if type-of($position) == list {
     $coordinates: $position;
     $position: relative;
   }
 
   $coordinates: unpack($coordinates);
-
-  $top: nth($coordinates, 1);
-  $right: nth($coordinates, 2);
-  $bottom: nth($coordinates, 3);
-  $left: nth($coordinates, 4);
+  $directions: (top: nth($coordinates, 1), right: nth($coordinates, 2), bottom: nth($coordinates, 3), left: nth($coordinates, 4));
 
   position: $position;
 
-  @if ($top and $top == auto) or (type-of($top) == number) {
-    top: $top;
-  }
-
-  @if ($right and $right == auto) or (type-of($right) == number) {
-    right: $right;
-  }
-
-  @if ($bottom and $bottom == auto) or (type-of($bottom) == number) {
-    bottom: $bottom;
-  }
-
-  @if ($left and $left == auto) or (type-of($left) == number) {
-    left: $left;
+  @each $direction, $value in $directions {
+    @if $value and "#{$value}" != "0" {
+      #{$direction}: #{$value};
+    }
   }
 }


### PR DESCRIPTION
I was having an issue where `+position(absolute, 10px 0 0 10px)` would compile to:

``` css
position: absolute;
top: 10px;
right: 0;
bottom: 0;
left: 10px;
```

When I should have gotten:

``` css
position: absolute;
top: 10px;
left: 10px;
```

I fixed that issue and refactored it to use a [sass 3.3 map](http://blog.sass-lang.com/posts/184094-sass-33-is-released)
