### PR TITLE
Add-on for forcing scrollbars in an element

### DIFF
--- a/app/assets/stylesheets/addons/_force-scrollbars.scss
+++ b/app/assets/stylesheets/addons/_force-scrollbars.scss
@@ -1,0 +1,26 @@
+@mixin force-scrollbars($bg: #fff, $size: 11px) {
+	$radius: $size * .75;
+
+	&::-webkit-scrollbar {
+	    -webkit-appearance: none;
+
+	    &:vertical {
+		    width: $size;
+		}
+
+		&:horizontal {
+	    	height: $size;
+		}
+
+		&-thumb {
+		    border-radius: $size;
+		    border: 2px solid $bg;
+		    background-color: rgba(#000, .5);
+		}
+
+		&-track { 
+		    background-color: $bg; 
+		    border-radius: $radius;
+		}
+	}
+}


### PR DESCRIPTION
Sometimes you want an overflowed element to always show scrollbars. Well, this will do the trick.

Note: it requires a background color, which should match the background of your element. Cannot be transparent.
