### PR TITLE
Add global $asset-pipeline setting

### DIFF
--- a/app/assets/stylesheets/_bourbon.scss
+++ b/app/assets/stylesheets/_bourbon.scss
@@ -1,6 +1,7 @@
 // Settings
 @import "settings/prefixer";
 @import "settings/px-to-em";
+@import "settings/asset-pipeline";
 
 // Custom Helpers
 @import "helpers/convert-units";

--- a/app/assets/stylesheets/addons/_retina-image.scss
+++ b/app/assets/stylesheets/addons/_retina-image.scss
@@ -1,4 +1,4 @@
-@mixin retina-image($filename, $background-size, $extension: png, $retina-filename: null, $retina-suffix: _2x, $asset-pipeline: false) {
+@mixin retina-image($filename, $background-size, $extension: png, $retina-filename: null, $retina-suffix: _2x, $asset-pipeline: $asset-pipeline) {
   @if $asset-pipeline {
     background-image: image-url("#{$filename}.#{$extension}");
   }

--- a/app/assets/stylesheets/css3/_font-face.scss
+++ b/app/assets/stylesheets/css3/_font-face.scss
@@ -1,6 +1,6 @@
 // Order of the includes matters, and it is: normal, bold, italic, bold+italic.
 
-@mixin font-face($font-family, $file-path, $weight: normal, $style: normal, $asset-pipeline: false ) {
+@mixin font-face($font-family, $file-path, $weight: normal, $style: normal, $asset-pipeline: $asset-pipeline) {
   @font-face {
     font-family: $font-family;
     font-weight: $weight;

--- a/app/assets/stylesheets/settings/_asset-pipeline.scss
+++ b/app/assets/stylesheets/settings/_asset-pipeline.scss
@@ -1,0 +1,1 @@
+$asset-pipeline: false !default;

--- a/dist/_bourbon.scss
+++ b/dist/_bourbon.scss
@@ -1,6 +1,7 @@
 // Settings
 @import "settings/prefixer";
 @import "settings/px-to-em";
+@import "settings/asset-pipeline";
 
 // Custom Helpers
 @import "helpers/convert-units";

--- a/dist/addons/_retina-image.scss
+++ b/dist/addons/_retina-image.scss
@@ -1,4 +1,4 @@
-@mixin retina-image($filename, $background-size, $extension: png, $retina-filename: null, $retina-suffix: _2x, $asset-pipeline: false) {
+@mixin retina-image($filename, $background-size, $extension: png, $retina-filename: null, $retina-suffix: _2x, $asset-pipeline: $asset-pipeline) {
   @if $asset-pipeline {
     background-image: image-url("#{$filename}.#{$extension}");
   }

--- a/dist/css3/_font-face.scss
+++ b/dist/css3/_font-face.scss
@@ -1,6 +1,6 @@
 // Order of the includes matters, and it is: normal, bold, italic, bold+italic.
 
-@mixin font-face($font-family, $file-path, $weight: normal, $style: normal, $asset-pipeline: false ) {
+@mixin font-face($font-family, $file-path, $weight: normal, $style: normal, $asset-pipeline: $asset-pipeline) {
   @font-face {
     font-family: $font-family;
     font-weight: $weight;

--- a/dist/settings/_asset-pipeline.scss
+++ b/dist/settings/_asset-pipeline.scss
@@ -1,0 +1,1 @@
+$asset-pipeline: false !default;


### PR DESCRIPTION
This pull request creates a global setting for `$asset-pipeline` that is honored in the methods that deal with the asset pipeline. The use case for me is that for example `retina-image` mixins will be a lot easier to write and read. With this addition instead of writing stuff like this everywhere:

``` scss
.logo {
  +retina-image(logo, 161px 50px, png, null, null, true);
}
```

it will be possible to write the sweeter and shorter:

``` scss
.logo {
  +retina-image(logo, 161px 50px);
}
```

By simply setting `$asset-pipeline: true` in `application.scss` once. By keeping it as the last argument for those mixins it is still possible to override the global setting if needed. 

I'm not sure if this is an desirable addition to Bourbon, so I'm curious what you think.
