### PR TITLE
Add better installation instructions for old versions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -71,13 +71,13 @@ You can specify a target directory using the `path` flag:
 
 ###### Install for older versions of Sass
 
-If you are using a version of Sass older than 3.3.x (This includes alternative implementations like libsass or sass-rails and frameworks like ZURB Foundation or Compass), Bourbon 4 will not work.
+If you are using a version of Sass older than 3.3.x (This includes alternative implementations like libsass or sass-rails and frameworks like ZURB Foundation or Compass), Bourbon 4.x will not work.
 
 Use the `-v` flag to install a specific version of the bourbon gem.
 
     gem install bourbon -v 3.2.1
 
-If you have install Bourbon 4.x in error, you may want to remove it.
+If you have installed Bourbon 4.x in error, you may want to remove it.
 
     gem uninstall bourbon -v 4.0.1
 


### PR DESCRIPTION
Looking at how many issues are resolved by installing the correct version of Bourbon or Sass, a little more help in the description of the software seems appropriate.

This adds a paragraph to readme.md describing what (alternative implementations of Sass like libsass and sass-rails and some Frameworks (Compass, ZURB Foundation)) is affected and how to install the older version of Bourbon.

([Compass uses Sass 3.2.19](https://github.com/chriseppstein/compass/blob/stable/Gemfile#L11))
([The Foundation guides use libsass](http://foundation.zurb.com/docs/sass.html#using-foundation-with-grunt-libsass))
