### PR TITLE
Add vertical align baseline to button mixin

### DIFF
--- a/app/assets/stylesheets/addons/_button.scss
+++ b/app/assets/stylesheets/addons/_button.scss
@@ -126,6 +126,7 @@
   padding: $padding;
   text-decoration: none;
   text-shadow: 0 1px 0 $text-shadow;
+  vertical-align: baseline;
   background-clip: padding-box;
 
   &:hover:not(:disabled) {
@@ -347,6 +348,7 @@
   font-weight: bold;
   padding: 7px 18px;
   text-decoration: none;
+  vertical-align: baseline;
   background-clip: padding-box;
 
   &:hover:not(:disabled){


### PR DESCRIPTION
Currently vertical-align for buttons is not specified. This can result in strange alignment issues (see attached). `vertical-align: baseline` results in a more constant appearance.
![button-valign](https://cloud.githubusercontent.com/assets/2489247/2998715/1d0b9c74-dd0e-11e3-8c98-73bbecc60344.png)
