### PR TITLE
Use `SASS_PATH` vs `Sass.load_paths` to avoid loading race conditions.

### DIFF
--- a/lib/bourbon.rb
+++ b/lib/bourbon.rb
@@ -23,10 +23,6 @@ module Bourbon
     end
   else
     bourbon_path = File.expand_path("../../app/assets/stylesheets", __FILE__)
-    if ENV.has_key?("SASS_PATH")
-      ENV["SASS_PATH"] = ENV["SASS_PATH"] + File::PATH_SEPARATOR + bourbon_path
-    else
-      ENV["SASS_PATH"] = bourbon_path
-    end
+    ENV["SASS_PATH"] = [ENV["SASS_PATH"], bourbon_path].compact.join(File::PATH_SEPARATOR)
   end
 end


### PR DESCRIPTION
I am writing an internal style gem that uses Bourbon, Susy, and Team-Sass/breakpoint. Each have their own ruby gem and each follow current Sass 3.3 [best practice](https://github.com/ericam/susy/blob/master/lib/susy.rb) by adding their path using `SASS_PATH`, except for Bourbon. From Sass's [changelog](https://github.com/nex3/sass/blob/stable/doc-src/SASS_CHANGELOG.md) for v3.3.0 release

> The automatic placement of the current working directory onto the Sass load path is now deprecated as this causes unpredictable build processes. If you need the current working directory to be available, set SASS_PATH=. in your shell's environment.

Not doing this and calling `Sass.load_paths` will nullify any gem doing the right thing with `SASS_PATH` that is unlucky enough to be loaded after Bourbon since calling `Sass.load_paths` will only parse the `SASS_PATH` just once, [see here](https://github.com/nex3/sass/blob/stable/lib/sass.rb#L42-L48). This patch fixes Bourbon by leveraging `SASS_PATH`.
