### PR TITLE
Use `Sass.load_paths` if `ENV['SASS_PATH']` not available.

### DIFF
--- a/lib/bourbon.rb
+++ b/lib/bourbon.rb
@@ -2,7 +2,7 @@
 dir = File.dirname(__FILE__)
 $LOAD_PATH.unshift dir unless $LOAD_PATH.include?(dir)
 
-require "bourbon/generator"
+require 'bourbon/generator'
 
 unless defined?(Sass)
   require 'sass'
@@ -17,12 +17,17 @@ module Bourbon
     module Rails
       class Railtie < ::Rails::Railtie
         rake_tasks do
-          load "tasks/install.rake"
+          load 'tasks/install.rake'
         end
       end
     end
   else
-    bourbon_path = File.expand_path("../../app/assets/stylesheets", __FILE__)
-    ENV["SASS_PATH"] = [ENV["SASS_PATH"], bourbon_path].compact.join(File::PATH_SEPARATOR)
+    bourbon_path = File.expand_path('../../app/assets/stylesheets', __FILE__)
+
+    if ENV.has_key?('SASS_PATH')
+      ENV['SASS_PATH'] = [ENV['SASS_PATH'], bourbon_path].compact.join(File::PATH_SEPARATOR)
+    else
+      Sass.load_paths << bourbon_path
+    end
   end
 end


### PR DESCRIPTION
Hey there,

unfortunately the commit https://github.com/thoughtbot/bourbon/commit/88fcaf30ff631dd9954462590f5aa3ea2ae00fce breaks the integration with https://github.com/locomotivecms/wagon.

Maybe @metaskills should look over the patch, whether it is ok to fall back to `Sass.load_paths` if `ENV['SASS_PATH']` not available.

PS: Many thanks for Bourbon!
