### PR TITLE
Аdded support for pixel values ​​for "size" mixin

### DIFF
--- a/app/assets/stylesheets/addons/_size.scss
+++ b/app/assets/stylesheets/addons/_size.scss
@@ -8,9 +8,13 @@
 
   @if $height == auto or (type-of($height) == number and not unitless($height)) {
     height: $height;
+  } @else {
+      height: ($height) + px;
   }
 
   @if $width == auto or (type-of($width) == number and not unitless($width)) {
     width: $width;
+  } @else {
+      width: ($width) + px;
   }
 }


### PR DESCRIPTION
There is some problem in this case:

$width: 350;
$height: 200;

.wrapper {
    @include size($width $height);
}

Sass compiles nothing and don't show  any errors, this looks a little bit strange. This fix can help with compiling mixin for every type of value(100, 100px, auto).
