### PR TITLE
Add version to main manifest file - Closes #430

### DIFF
--- a/app/assets/stylesheets/_bourbon.scss
+++ b/app/assets/stylesheets/_bourbon.scss
@@ -1,3 +1,8 @@
+/* Bourbon 4.0.2
+ * http://bourbon.io
+ * Copyright 2011–2014 thoughtbot, inc.
+ * MIT License */
+
 // Settings
 @import "settings/prefixer";
 @import "settings/px-to-em";

--- a/dist/_bourbon.scss
+++ b/dist/_bourbon.scss
@@ -1,3 +1,8 @@
+/* Bourbon 4.0.2
+ * http://bourbon.io
+ * Copyright 2011–2014 thoughtbot, inc.
+ * MIT License */
+
 // Settings
 @import "settings/prefixer";
 @import "settings/px-to-em";


### PR DESCRIPTION
For those who don’t use Bourbon in Rails or with some sort of package manager and instead simply download the Bourbon files, it can be difficult to tell what version they are using. This adds the typical convention of included the version in the main manifest.

This is exactly how [Bitters does it](https://github.com/thoughtbot/bitters/blob/master/app/assets/stylesheets/_base.scss).
