### PR TITLE
Add note about installing older versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,17 +13,50 @@ Bourbon is a library of pure Sass mixins that are designed to be simple and easy
 
 The mixins contain vendor specific prefixes for all CSS3 properties for support amongst modern browsers. The prefixes also ensure graceful degradation for older browsers that support only CSS3 prefixed properties. Bourbon uses SCSS syntax.
 
-### [Documentation & Demo](http://bourbon.io)
+#### [Documentation & Demo](http://bourbon.io)
+
+#### [Changelog](https://github.com/thoughtbot/bourbon/releases)
 
 ## Requirements
 
 - Sass 3.3+
+- :warning: If you are using Bourbon with **LibSass**, **sass-rails**, **Compass**, **Foundation** or need **Sass 3.2 support**, you should [use Bourbon 3.2.x](#installing-older-versions-of-bourbon).
 
-:warning: If you are using **LibSass** or **sass-rails**, or need Sass 3.2 support, use Bourbon **3.2.x**.
+## Installation
+
+Bourbon uses the [RubyGems](https://rubygems.org) package manager to easily generate a `bourbon` directory with all of the necessary files.
+
+For command line help, use `bourbon help` or visit the [Command Line Interface Wiki](https://github.com/thoughtbot/bourbon/wiki/Command-Line-Interface).
+
+1. Install the Bourbon gem:
+
+  ```bash
+  gem install bourbon
+  ```
+
+2. Install the Bourbon library into the current directory:
+
+  ```bash
+  bourbon install
+  ```
+
+  **Pro Tip:** You can specify a target directory using the `path` flag:
+
+  ```bash
+  bourbon install --path my/custom/path/
+  ```
+
+3. Import Bourbon at the beginning of your stylesheet:
+
+  ```scss
+  @import "bourbon/bourbon";
+  ```
+
+  It’s not recommended to add or modify the Bourbon files so that you can update Bourbon easily.
 
 ## Installation for Rails 3.1+
 
-1. In your Gemfile:
+1. Add Bourbon to your Gemfile:
 
   ```ruby
   gem 'bourbon'
@@ -41,7 +74,7 @@ The mixins contain vendor specific prefixes for all CSS3 properties for support 
   mv app/assets/stylesheets/application.css app/assets/stylesheets/application.css.scss
   ```
 
-4. Delete the sprocket directive in `application.css.scss` ([Why?](https://github.com/thoughtbot/bourbon/wiki/Rails-Sprockets)):
+4. Delete the sprocket directive in `application.css.scss` ([why?](https://github.com/thoughtbot/bourbon/wiki/Rails-Sprockets)):
 
   ```scss
   *= require_tree .
@@ -55,54 +88,42 @@ The mixins contain vendor specific prefixes for all CSS3 properties for support 
   @import "users";
   ```
 
-[Help! I’m getting an undefined mixin error.](https://github.com/thoughtbot/bourbon/wiki/Rails-Help-%5C-Undefined-mixin)
+  [Help! I’m getting an undefined mixin error.](https://github.com/thoughtbot/bourbon/wiki/Rails-Help-%5C-Undefined-mixin)
 
-- [Rails 3.0.x installation instructions](https://github.com/thoughtbot/bourbon/wiki/Rails-3.0.x-Install)
-- [Rails 2.3 installation instructions](https://github.com/thoughtbot/bourbon/wiki/Bourbon-v2.x-or-Rails-2.3-Install)
+## Installing older versions of Bourbon
 
-## Installation for Non-Rails projects
-
-Bourbon includes an easy way to generate a directory with all the necessary files. For command line help, use `bourbon help` or visit the [Command Line Tools Wiki](https://github.com/thoughtbot/bourbon/wiki/Command-Line-Tools).
-
-1. Install (Bourbon 3.0+):
+1. Uninstall any Bourbon gem versions you already have:
 
   ```bash
-  gem install bourbon
+  gem uninstall bourbon
   ```
 
-2. Install Bourbon into the current directory by generating the `bourbon` folder:
+2. Reinstall the Bourbon gem, using the `-v` flag to specify the version you need:
 
   ```bash
-  bourbon install
+  gem install bourbon -v 3.2.3
   ```
 
-  The generated folder will contain all the mixins and other necessary Bourbon files. It is recommended not to add or modify the Bourbon files so that you can update Bourbon easily.
+3. Follow the [instructions above](#installation) to install Bourbon into your project.
 
-  You can specify a target directory using the `path` flag:
-
-  ```bash
-  bourbon install --path my/custom/path/
-  ```
-
-3. Import Bourbon at the beginning of your stylesheet:
-
-  ```scss
-  @import "bourbon/bourbon";
-  ```
-
-_Note: Bourbon no longer requires a custom `sass --watch` command for Bourbon v3.0+_
-
-#### Other Commands
+## Command line interface
 
 ```bash
 bourbon help
+bourbon install
 bourbon update
+bourbon version
 ```
 
-#### [Bourbon v2.x install instructions](https://github.com/thoughtbot/bourbon/wiki/Bourbon-v2.x-or-Rails-2.3-Install)
+More information can be found in the [wiki](https://github.com/thoughtbot/bourbon/wiki/Command-Line-Interface).
 
-- [Changelog](https://github.com/thoughtbot/bourbon/releases)
-- [Browser support](https://github.com/thoughtbot/bourbon/wiki/Browser-Support)
+## Browser support
+
+- Firefox 3.6+
+- Safari 5.1+
+- Chrome 10.0+
+- Opera 12+
+- Internet Explorer 9+
 
 ## The Bourbon family
 
@@ -119,4 +140,4 @@ Bourbon is maintained and funded by [thoughtbot, inc](http://thoughtbot.com). Tw
 
 ## License
 
-Bourbon is Copyright © 2011–2014 thoughtbot. It is free software, and may be redistributed under the terms specified in the [LICENSE](LICENSE.md) file.
+Copyright © 2011–2014 [thoughtbot, inc](http://thoughtbot.com). Bourbon is free software, and may be redistributed under the terms specified in the [license](LICENSE.md).


### PR DESCRIPTION
- Add instructions for installing older version of Bourbon (per PR #424)
- Move up regular, non-Rails installation instructions to be before Rails installation (same order as [Neat’s README](https://github.com/thoughtbot/neat/blob/master/README.md))
- Refine some wording
- Add browser support from wiki
- Refine note about command line interface and link to wiki
