### PR TITLE
Flat button style should be passed $padding and $text-size arguments

### DIFF
--- a/app/assets/stylesheets/addons/_button.scss
+++ b/app/assets/stylesheets/addons/_button.scss
@@ -343,9 +343,9 @@
   border: none;
   color: $color;
   display: inline-block;
-  font-size: inherit;
+  font-size: $textsize;
   font-weight: bold;
-  padding: 7px 18px;
+  padding: $padding;
   text-decoration: none;
   background-clip: padding-box;
 

--- a/dist/addons/_button.scss
+++ b/dist/addons/_button.scss
@@ -343,9 +343,9 @@
   border: none;
   color: $color;
   display: inline-block;
-  font-size: inherit;
+  font-size: $textsize;
   font-weight: bold;
-  padding: 7px 18px;
+  padding: $padding;
   text-decoration: none;
   background-clip: padding-box;
 


### PR DESCRIPTION
Make it possible to pass arguments to flat buttons as done in other button mixins: `flat(white, $padding: 12px, $textsize: 12px)`
