### PR TITLE
Update title and section id

### DIFF
--- a/_includes/settings/prefixer-settings.html
+++ b/_includes/settings/prefixer-settings.html
@@ -1,6 +1,6 @@
-<article id="prefixer-settings" data-type="option">
+<article id="global-prefixer" data-type="option">
   <header class="title-bar">
-    <h2 class="title">Prefixer Settings</h2>
+    <h2 class="title">Global Prefixer</h2>
     <a class="view-source" href="https://github.com/thoughtbot/bourbon/blob/master/app/assets/stylesheets/addons/_prefixer.scss">View source</a>
   </header>
   <p>By default, Bourbon outputs all vendor-prefixes specified by each mixin. You can optionally overwrite these global defaults by setting any of these variables to <code>false</code> at the top of your stylesheet.</p>


### PR DESCRIPTION
Updating title so it uses the same copy of the navigation menu. Updating the id so the navigation link anchor works correctly.
