### PR TITLE
[Issue #498] Added $transparency paramenter to linear-gradient mixin to support layered gradients

### DIFF
--- a/app/assets/stylesheets/css3/_linear-gradient.scss
+++ b/app/assets/stylesheets/css3/_linear-gradient.scss
@@ -3,7 +3,8 @@
                        $G5: null, $G6: null,
                        $G7: null, $G8: null,
                        $G9: null, $G10: null,
-                       $fallback: null) {
+                       $fallback: null,
+                       $transparency: false) {
   // Detect what type of value exists in $pos
   $pos-type: type-of(nth($pos, 1));
   $pos-spec: null;
@@ -30,6 +31,11 @@
   // If $fallback is a color use that color as the fallback color
   @if (type-of($fallback) == color) or ($fallback == "transparent") {
     $fallback-color: $fallback;
+  }
+
+  // If $transparency is true use white transparency as the fallback color
+  @if ($transparency) {
+    $fallback-color: rgba(255, 255, 255, 0);
   }
 
   background-color: $fallback-color;


### PR DESCRIPTION
Added optional `$transparency` variable in the event you want to force transparent `background-color`. `$fallback` will always take the first color stop if it's not set in the mixin. By forcing a transparent background, you can do layered gradient effects.