### PR TITLE
Solved error in _background.scss

### DIFF
--- a/dist/css3/_background.scss
+++ b/dist/css3/_background.scss
@@ -12,7 +12,7 @@
     $spec-background: ();
     $background-type: type-of($background);
 
-    @if $background-type == string or list {
+    @if $background-type == string or $background-type == list {
       $background-str: if($background-type == list, nth($background, 1), $background);
 
       $url-str:       str-slice($background-str, 0, 3);


### PR DESCRIPTION
Solved error: `error scss/bourbon/css3/_background.scss(Line 18: $string: #dfdfd1 is not a string for 'str-slice')`.
This error happens when passing only a color to background mixin.
Like this: `@include background(#dfdfd1)`.
