### PR TITLE
Fix for background.scss in app/ that PR#516 added to dist/

### DIFF
--- a/app/assets/stylesheets/css3/_background.scss
+++ b/app/assets/stylesheets/css3/_background.scss
@@ -12,7 +12,7 @@
     $spec-background: ();
     $background-type: type-of($background);
 
-    @if $background-type == string or list {
+    @if $background-type == string or $background-type == list {
       $background-str: if($background-type == list, nth($background, 1), $background);
 
       $url-str:       str-slice($background-str, 0, 3);


### PR DESCRIPTION
#516 added a fix to the Bower `dist/` directory (soon to be deprecated), this adds the same fix to `app/assets/stylesheets`
