### PR TITLE
Add CSS3 text-decoration mixin

### DIFF
--- a/app/assets/stylesheets/css3/_text-decoration.scss
+++ b/app/assets/stylesheets/css3/_text-decoration.scss
@@ -1,0 +1,19 @@
+@mixin text-decoration($value) {
+// <text-decoration-line> || <text-decoration-style> || <text-decoration-color>
+  @include prefixer(text-decoration, $value, moz);
+}
+
+@mixin text-decoration-line($line: none) {
+// none || underline || overline || line-through
+  @include prefixer(text-decoration-line, $line, moz);
+}
+
+@mixin text-decoration-style($style: solid) {
+// solid || double || dotted || dashed || wavy
+  @include prefixer(text-decoration-style, $style, moz webkit);
+}
+
+@mixin text-decoration-color($color: currentColor) {
+// currentColor || <color>
+  @include prefixer(text-decoration-color, $color, moz);
+}


### PR DESCRIPTION
Adds support for CSS3’s extension of the [`text-decoration` property](http://dev.w3.org/csswg/css-text-decor-3).

Closes #509

**Note**: Needs documentation
