### PR TITLE
Correct alternate value for space-around

### DIFF
--- a/app/assets/stylesheets/css3/_flex-box.scss
+++ b/app/assets/stylesheets/css3/_flex-box.scss
@@ -233,7 +233,7 @@
     }
 
     @elseif $value == "space-around" {
-        $alt-value: center;
+        $alt-value: distribute;
     }
 
     // 2009


### PR DESCRIPTION
Correct alternate value for justify-content:space-around for IE shoud be "distribute".
