### PR TITLE
Deprecate the golden ratio function

### DIFF
--- a/app/assets/stylesheets/_bourbon-deprecated-upcoming.scss
+++ b/app/assets/stylesheets/_bourbon-deprecated-upcoming.scss
@@ -403,3 +403,9 @@
   @return $n * $gw-column + ($n - 1) * $gw-gutter;
   @warn "grid-width function is deprecated and will be removed in the next major version release";
 }
+
+// Golden ratio
+@function golden-ratio($increment) {
+  @return modular-scale($increment, $ratio: $golden)
+  @warn "The golden-ratio function is deprecated and will be removed in the next major version release. Please use the modular-scale function, instead.";
+}

--- a/app/assets/stylesheets/_bourbon.scss
+++ b/app/assets/stylesheets/_bourbon.scss
@@ -27,7 +27,6 @@
 @import "functions/assign";
 @import "functions/color-lightness";
 @import "functions/flex-grid";
-@import "functions/golden-ratio";
 @import "functions/grid-width";
 @import "functions/px-to-em";
 @import "functions/px-to-rem";

--- a/app/assets/stylesheets/functions/_golden-ratio.scss
+++ b/app/assets/stylesheets/functions/_golden-ratio.scss
@@ -1,3 +1,0 @@
-@function golden-ratio($increment) {
-  @return modular-scale($increment, $ratio: $golden)
-}


### PR DESCRIPTION
The `golden-ratio` function simply calls on the `modular-scale` function and chaining like this can make updating things hard. For example, I have a [PR](https://github.com/thoughtbot/bourbon/pull/440) up to add defaults to the `modular-scale` function, but when I change that, the `golden-ratio` function breaks; so it forces a change there, too.

I think we should just prefer use of the `modular-scale` function. Helps keep things simple and tidy.

**Note**: Neat uses `golden-ratio` to [set column and gutter defaults](https://github.com/thoughtbot/neat/blob/master/app/assets/stylesheets/settings/_grid.scss) and will need to be updated to just use `modular-scale` if this moves forward.
- [x] Add deprecation note to the [Bourbon documentation](http://bourbon.io/docs/#golden-ratio)
- [x] Update Neat to use `modular-scale` instead of `golden-ratio` for its `column` & `gutter` settings
- [x] Update Neat documentation which mentions `golden-ratio` in the [`column`](http://thoughtbot.github.io/neat-docs/latest/#column) and [`gutter`](http://thoughtbot.github.io/neat-docs/latest/#gutter) sections
