### PR TITLE
Remove unnecessary string interpolations

### DIFF
--- a/app/assets/stylesheets/css3/_hidpi-media-query.scss
+++ b/app/assets/stylesheets/css3/_hidpi-media-query.scss
@@ -3,8 +3,8 @@
   @media only screen and (-webkit-min-device-pixel-ratio: $ratio),
   only screen and (min--moz-device-pixel-ratio: $ratio),
   only screen and (-o-min-device-pixel-ratio: #{$ratio}/1),
-  only screen and (min-resolution: #{round($ratio*96)}dpi),
-  only screen and (min-resolution: #{$ratio}dppx) {
+  only screen and (min-resolution: round($ratio * 96dpi)),
+  only screen and (min-resolution: $ratio * 1dppx) {
     @content;
   }
 }

--- a/dist/css3/_hidpi-media-query.scss
+++ b/dist/css3/_hidpi-media-query.scss
@@ -3,8 +3,8 @@
   @media only screen and (-webkit-min-device-pixel-ratio: $ratio),
   only screen and (min--moz-device-pixel-ratio: $ratio),
   only screen and (-o-min-device-pixel-ratio: #{$ratio}/1),
-  only screen and (min-resolution: #{round($ratio*96)}dpi),
-  only screen and (min-resolution: #{$ratio}dppx) {
+  only screen and (min-resolution: round($ratio * 96dpi)),
+  only screen and (min-resolution: $ratio * 1dppx) {
     @content;
   }
 }


### PR DESCRIPTION
Removing string interpolations and relying on operations I think the
source looks a bit more clear. Buy maybe that’s just me.
