### PR TITLE
Change logo in README to SVG

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Bourbon Sass Mixin Library](http://bourbon.io/images/shared/bourbon-logo.png)](http://bourbon.io)
+[![Bourbon Sass Mixin Library](http://images.thoughtbot.com/bourbon/bourbon-logo.svg)](http://bourbon.io)
 
 [![Gem Version](http://img.shields.io/gem/v/bourbon.svg?style=flat)](https://rubygems.org/gems/bourbon)
 [![Code Climate](http://img.shields.io/codeclimate/github/thoughtbot/bourbon.svg?style=flat)](https://codeclimate.com/github/thoughtbot/bourbon)


### PR DESCRIPTION
Because retina and resolution-independence, man.

Question: is this a proper use of the images.thoughtbot.com S3 CDN?

I would love to also update the thoughtbot logo in the `README` to be SVG (and the newer version of the logo). Should that be on images.thoughtbot.com?
