### PR TITLE
hide-text for non-English Characters

### DIFF
--- a/app/assets/stylesheets/addons/_hide-text.scss
+++ b/app/assets/stylesheets/addons/_hide-text.scss
@@ -1,4 +1,5 @@
 @mixin hide-text {
+  line-height: 1.5;
   overflow: hidden;
 
   &:before {


### PR DESCRIPTION
This mixin will not work perfectly if line-height is 1 for Japanese. (maybe Chinese also).
Set line-height to 1.X will be safer.

![screenshot-web lobi co 2014-10-21 14-06-44](https://cloud.githubusercontent.com/assets/2394070/4713417/acf401e8-58e0-11e4-82fd-a01e76f62324.png)
