### PR TITLE
Fix selection mixin code spacing

### DIFF
--- a/_includes/mixins/selection.html
+++ b/_includes/mixins/selection.html
@@ -6,34 +6,34 @@
     </header>
     <p>Outputs vendor-prefixed selection selectors for styling. Can be included at base level.</p>
 
-    {% highlight scss %}
-    @include selection {
-      background-color: white;
-    }
+{% highlight scss %}
+@include selection {
+  background-color: white;
+}
 
-    p {
-      @include selection {
-        background-color: black;
-        color: white;
-      }
-    }
-    {% endhighlight %}
-    <h3>CSS Output</h3>
-    {% highlight scss %}
-    ::selection {
-      background-color: white;
-    }
-    ::-moz-selection {
-      background-color: white;
-    }
+p {
+  @include selection {
+    background-color: black;
+    color: white;
+  }
+}
+{% endhighlight %}
+<h3>CSS Output</h3>
+{% highlight scss %}
+::selection {
+  background-color: white;
+}
+::-moz-selection {
+  background-color: white;
+}
 
-    p::selection {
-      background-color: black;
-      color: white;
-    }
-    p::-moz-selection {
-      background-color: black;
-      color: white;
-    }
-    {% endhighlight %}
+p::selection {
+  background-color: black;
+  color: white;
+}
+p::-moz-selection {
+  background-color: black;
+  color: white;
+}
+{% endhighlight %}
 </article>


### PR DESCRIPTION
There seems to be an issue with the spacing of the code example on the docs, as seen here: http://i.imgur.com/Wposk30.png.  This removes the spaces, fixing the odd indentation.  The other mixins with code blocks do this as well.
