### PR TITLE
Allow hide-text addon to accept height argument

### DIFF
--- a/app/assets/stylesheets/addons/_hide-text.scss
+++ b/app/assets/stylesheets/addons/_hide-text.scss
@@ -1,8 +1,9 @@
-@mixin hide-text {
+@mixin hide-text($height: 1em) {
+  height: $height;
   line-height: 1.5;
   overflow: hidden;
 
-  &:before {
+  &::before {
     content: "";
     display: block;
     width: 0;


### PR DESCRIPTION
- Added the ability to pass a height value (default is `1em`) to the `hide-text` addon, since one is required for it to work.
- Changed the pseudo-element to use two colons instead of one, per [MDN’s note](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-elements#Notes).
- Fixes #551
