### PR TITLE
Refactor size mixin

### DIFF
--- a/app/assets/stylesheets/_bourbon.scss
+++ b/app/assets/stylesheets/_bourbon.scss
@@ -27,14 +27,14 @@
 @import "functions/assign";
 @import "functions/color-lightness";
 @import "functions/contains";
+@import "functions/is-length";
+@import "functions/is-size";
 @import "functions/px-to-em";
 @import "functions/px-to-rem";
 @import "functions/strip-units";
 @import "functions/tint-shade";
 @import "functions/transition-property-name";
 @import "functions/unpack";
-@import "functions/validate-length";
-@import "functions/validate-size";
 @import "functions/modular-scale";
 
 // CSS3 Mixins

--- a/app/assets/stylesheets/addons/_size.scss
+++ b/app/assets/stylesheets/addons/_size.scss
@@ -1,16 +1,26 @@
-@mixin size($size) {
-  $height: nth($size, 1);
-  $width: $height;
+// Set `width` and `height` in a single statement
 
-  @if length($size) > 1 {
-    $height: nth($size, 2);
+@mixin size($value) {
+  $width: nth($value, 1);
+  $height: $width;
+
+  @if length($value) > 1 {
+    $height: nth($value, 2);
   }
 
-  @if $height == auto or (type-of($height) == number and not unitless($height)) {
+  @if is-size($height) {
     height: $height;
   }
 
-  @if $width == auto or (type-of($width) == number and not unitless($width)) {
+  @else {
+    @warn "`#{$height}` is not a valid length for the `$height` parameter in the `size` mixin.";
+  }
+
+  @if is-size($width) {
     width: $width;
+  }
+
+  @else {
+    @warn "`#{$width}` is not a valid length for the `$width` parameter in the `size` mixin.";
   }
 }

--- a/app/assets/stylesheets/functions/_is-length.scss
+++ b/app/assets/stylesheets/functions/_is-length.scss
@@ -1,4 +1,4 @@
-// Check whether `$value` is a valid length.
+// Check for a valid length
 
 @function is-length($value) {
   @return contains(0 "auto" "initial" "inherit", $value)

--- a/app/assets/stylesheets/functions/_is-size.scss
+++ b/app/assets/stylesheets/functions/_is-size.scss
@@ -1,4 +1,4 @@
-// Check whether `$value` is a valid size.
+// Check for a valid size
 
 @function is-size($value) {
   @return is-length($value)


### PR DESCRIPTION
- Allow `auto`, `inherit`, and `initial` values
- Allow unitless number values
- Allow intrinsic sizing values (`fill`, `max-content`, `min-content`, `fit-content`)
- Allow `calc()` CSS function
- Fixes #391
- Fixes #468

Many thanks to @HugoGiraudel for the help in the issues above and for writing [this article](http://www.sitepoint.com/bulletproof-function-validate-length-values-sass).

There’s one concern with this moving forward: it’s a breaking change (would have to wait for Bourbon v5.0). The previous mixin used a [variable argument](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#variable_arguments) approach (like this: `@include size(30px 70px);`), but this refactor uses a [comma-separated argument](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#mixin-arguments) approach (like this: `@include size(30px, 70px);`, note the comma).

Our [`linear-gradient`](http://bourbon.io/docs/#linear-gradient) mixin—for example—uses commas and I think the size addon should too, because the values passed are each going to their own property (`width` and `height`). Our [`em`](http://bourbon.io/docs/#px-to-em) function also uses commas.

How are we defining what uses commas and what doesn’t?
