### PR TITLE
Removes prefixer from border-radius shorthand mixin

### DIFF
--- a/app/assets/stylesheets/css3/_border-radius.scss
+++ b/app/assets/stylesheets/css3/_border-radius.scss
@@ -1,22 +1,22 @@
-//************************************************************************//
-// Shorthand Border-radius mixins
-//************************************************************************//
+// Border Radius (Shorthand)
+// Provides a shorthand syntax to target and add border radii to both corners on one side of a box
+
 @mixin border-top-radius($radii) {
-  @include prefixer(border-top-left-radius, $radii, spec);
-  @include prefixer(border-top-right-radius, $radii, spec);
-}
-
-@mixin border-bottom-radius($radii) {
-  @include prefixer(border-bottom-left-radius, $radii, spec);
-  @include prefixer(border-bottom-right-radius, $radii, spec);
-}
-
-@mixin border-left-radius($radii) {
-  @include prefixer(border-top-left-radius, $radii, spec);
-  @include prefixer(border-bottom-left-radius, $radii, spec);
+  border-top-left-radius: $radii;
+  border-top-right-radius: $radii;
 }
 
 @mixin border-right-radius($radii) {
-  @include prefixer(border-top-right-radius, $radii, spec);
-  @include prefixer(border-bottom-right-radius, $radii, spec);
+  border-bottom-right-radius: $radii;
+  border-top-right-radius: $radii;
+}
+
+@mixin border-bottom-radius($radii) {
+  border-bottom-left-radius: $radii;
+  border-bottom-right-radius: $radii;
+}
+
+@mixin border-left-radius($radii) {
+  border-bottom-left-radius: $radii;
+  border-top-left-radius: $radii;
 }


### PR DESCRIPTION
Quick preface: The [border radius shorthand mixins](http://bourbon.io/docs/#border-radius) are _not_ just a prefix-ing mixin for CSS3 `border-radius`. That was [already deprecated](https://github.com/thoughtbot/bourbon/commit/88dd7ed2dcee3e9eb7c7b258a2e1d84ea9d69d96). However, these shorthand mixins were still calling on the prefixer mixin, even though only spec was being output.

No need for this! This PR removes calling the prefixer mixin.

I also think we should tweak the docs to be more clear:
- [x] Change the title to “Border radius shorthand”
- [x] Remove deprecation note (it’s old news, by now)
- [x] Show the CSS output

Update: [PR for changing docs](https://github.com/thoughtbot/bourbon/pull/569)

In case it’s not clear, this current `border-radius` mixin allows you to target both corners of the side of a box in one line:

``` scss
@include border-right-radius(20px);
```

…which outputs:

``` css
border-top-right-radius: 20px;
border-bottom-right-radius: 20px;
```
