### PR TITLE
Update bower.json to install app dir 

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,6 @@
   "license": "MIT",
   "ignore": [
     "**/.*",
-    "app",
     "bin",
     "bourbon.gemspec",
     "CONTRIBUTING.md",


### PR DESCRIPTION
Since ./dist is removed in #480, the ./app directory is necessary for importing the files
when bourbon is loaded via bower. 

Currently this directory is ignored, via the ignore attribute of the bower.json file. 
