### PR TITLE
Deprecates the box-sizing mixin

### DIFF
--- a/app/assets/stylesheets/_bourbon-deprecated-upcoming.scss
+++ b/app/assets/stylesheets/_bourbon-deprecated-upcoming.scss
@@ -403,3 +403,10 @@
 
   @warn "The golden-ratio function is deprecated and will be removed in the next major version release. Please use the modular-scale function, instead.";
 }
+
+@mixin box-sizing($box) {
+  // content-box | border-box | inherit
+  @include prefixer(box-sizing, $box, webkit moz);
+
+  @warn "The box-sizing mixin is deprecated and will be removed in the next major version release. This property can now be used un-prefixed.";
+}

--- a/app/assets/stylesheets/_bourbon.scss
+++ b/app/assets/stylesheets/_bourbon.scss
@@ -47,7 +47,6 @@
 @import "css3/background-image";
 @import "css3/border-image";
 @import "css3/border-radius";
-@import "css3/box-sizing";
 @import "css3/calc";
 @import "css3/columns";
 @import "css3/filter";

--- a/app/assets/stylesheets/css3/_box-sizing.scss
+++ b/app/assets/stylesheets/css3/_box-sizing.scss
@@ -1,4 +1,0 @@
-@mixin box-sizing($box) {
-// content-box | border-box | inherit
-  @include prefixer(box-sizing, $box, webkit moz);
-}


### PR DESCRIPTION
Browser support is strong (94.66%), no longer need prefixes: http://caniuse.com/#feat=css3-boxsizing

To do:

- [ ] Update docs
- [x] [Update Neat](https://github.com/thoughtbot/neat/blob/master/app/assets/stylesheets/grid/_box-sizing.scss)