### PR TITLE
Refine docs for border radius shorthand mixin

### DIFF
--- a/_includes/mixins/border-radius.html
+++ b/_includes/mixins/border-radius.html
@@ -1,17 +1,29 @@
 <article id="border-radius" data-type="mixin">
   <header class="title-bar">
-    <h2 class="title">Border-radius</h2>
+    <h2 class="title">Border Radius (Shorthand)</h2>
     <a class="view-source" href="https://github.com/thoughtbot/bourbon/blob/master/app/assets/stylesheets/css3/_border-radius.scss">View source</a>
-    <a class="view-spec" href="https://developer.mozilla.org/en-US/docs/Web/CSS/border-radius">View spec</a>
   </header>
-  <p>The border-radius helper mixins provide shortcuts for targeting sides. These mixins are supported in Bourbon v3.0+</p>
+  <p>These mixins provide a shorthand syntax to target and add border radii to <em>both corners</em> on one side of a box.</p>
 
 {% highlight scss %}
 @include border-top-radius(5px);
+@include border-right-radius(5px);
 @include border-bottom-radius(5px);
 @include border-left-radius(5px);
-@include border-right-radius(5px);
 {% endhighlight %}
 
-  <p class="alert"><b>Deprecation Warning: </b>The official border-radius mixin was deprecated and removed in Bourbon 3.0. <a href="https://github.com/thoughtbot/bourbon/pull/95">Here's why.</a></p>
+  <h3>Example</h3>
+{% highlight scss %}
+.element {
+  @include border-top-radius(5px);
+}
+{% endhighlight %}
+
+  <h3>CSS Output</h3>
+{% highlight scss %}
+.element {
+  border-top-left-radius: 5px;
+  border-top-right-radius: 5px;
+}
+{% endhighlight %}
 </article>


### PR DESCRIPTION
Make the docs better indicate that this is a mixin for shorthand border-radius targeting, not for prefixing.
- Changed title
- Added example with CSS output
- Remove link to CSS `border-radius` spec

Related PR: #564
