### PR TITLE
FIX #556 refactor word-wrap

### DIFF
--- a/app/assets/stylesheets/addons/_word-wrap.scss
+++ b/app/assets/stylesheets/addons/_word-wrap.scss
@@ -1,8 +1,10 @@
 @mixin word-wrap($wrap: break-word) {
   word-wrap: $wrap;
+  overflow-wrap: $wrap;
 
-  @if $wrap == break-word {
-    overflow-wrap: break-word;
+  @if $wrap == break-word {    
     word-break: break-all;
+  } @else {
+    word-break: $wrap;
   }
 }


### PR DESCRIPTION
Small refactor of the `word-wrap` mixin. Moved `overflow-wrap` outside of the if statement since this actually is the new preferred CSS3 name, if not supported (not Chrome or Opera) `word-wrap` would be the fallback.

`word-break` gets the same value as `overflow-wrap` for `normal` and `inherit` which allows it to be reset.
