### PR TITLE
Make _render-gradients and _flex-box become compilable with sass-compiler libraries

### DIFF
--- a/app/assets/stylesheets/css3/_flex-box.scss
+++ b/app/assets/stylesheets/css3/_flex-box.scss
@@ -78,7 +78,7 @@
         display: flex;
     }
 
-    @elseif $value == "inline-flex" {
+    @else if $value == "inline-flex" {
         display: -webkit-inline-box;
         display: -moz-inline-box;
         display: inline-box;
@@ -124,16 +124,16 @@
         $value-2009: horizontal;
     }
 
-    @elseif $value == "row-reverse" {
+    @else if $value == "row-reverse" {
         $value-2009: horizontal;
         $direction: reverse;
     }
 
-    @elseif $value == column {
+    @else if $value == column {
         $value-2009: vertical;
     }
 
-    @elseif $value == "column-reverse" {
+    @else if $value == "column-reverse" {
         $value-2009: vertical;
         $direction: reverse;
     }
@@ -162,11 +162,11 @@
         $alt-value: single;
     }
 
-    @elseif $value == wrap {
+    @else if $value == wrap {
         $alt-value: multiple;
     }
 
-    @elseif $value == "wrap-reverse" {
+    @else if $value == "wrap-reverse" {
         $alt-value: multiple;
     }
 
@@ -224,15 +224,15 @@
         $alt-value: start;
     }
 
-    @elseif $value == "flex-end" {
+    @else if $value == "flex-end" {
         $alt-value: end;
     }
 
-    @elseif $value == "space-between" {
+    @else if $value == "space-between" {
         $alt-value: justify;
     }
 
-    @elseif $value == "space-around" {
+    @else if $value == "space-around" {
         $alt-value: center;
     }
 
@@ -257,7 +257,7 @@
         $alt-value: start;
     }    
 
-    @elseif $value == "flex-end" {
+    @else if $value == "flex-end" {
         $alt-value: end;
     }
 
@@ -280,7 +280,7 @@
         $value-2011: start;
     }    
 
-    @elseif $value == "flex-end" {
+    @else if $value == "flex-end" {
         $value-2011: end;
     }
 
@@ -300,15 +300,15 @@
         $value-2011: start;
     }    
 
-    @elseif $value == "flex-end" {
+    @else if $value == "flex-end" {
         $value-2011: end;
     }
 
-    @elseif $value == "space-between" {
+    @else if $value == "space-between" {
         $value-2011: justify;
     }
 
-    @elseif $value == "space-around" {
+    @else if $value == "space-around" {
         $value-2011: distribute;
     }
 

--- a/app/assets/stylesheets/helpers/_render-gradients.scss
+++ b/app/assets/stylesheets/helpers/_render-gradients.scss
@@ -16,11 +16,11 @@
   }
 
   @if $vendor {
-    $vendor-gradients: -#{$vendor}-#{$gradient-type}-gradient(#{$pre-spec} $gradients);
+    $vendor-gradients: "-#{$vendor}-#{$gradient-type}-gradient(#{$pre-spec} #{$gradients})";
   }
   @else if $vendor == false {
     $vendor-gradients: "#{$gradient-type}-gradient(#{$spec} #{$gradients})";
-    $vendor-gradients: unquote($vendor-gradients);
   }
+  $vendor-gradients: unquote($vendor-gradients);
   @return $vendor-gradients;
 }

--- a/dist/css3/_flex-box.scss
+++ b/dist/css3/_flex-box.scss
@@ -78,7 +78,7 @@
         display: flex;
     }
 
-    @elseif $value == "inline-flex" {
+    @else if $value == "inline-flex" {
         display: -webkit-inline-box;
         display: -moz-inline-box;
         display: inline-box;
@@ -124,16 +124,16 @@
         $value-2009: horizontal;
     }
 
-    @elseif $value == "row-reverse" {
+    @else if $value == "row-reverse" {
         $value-2009: horizontal;
         $direction: reverse;
     }
 
-    @elseif $value == column {
+    @else if $value == column {
         $value-2009: vertical;
     }
 
-    @elseif $value == "column-reverse" {
+    @else if $value == "column-reverse" {
         $value-2009: vertical;
         $direction: reverse;
     }
@@ -162,11 +162,11 @@
         $alt-value: single;
     }
 
-    @elseif $value == wrap {
+    @else if $value == wrap {
         $alt-value: multiple;
     }
 
-    @elseif $value == "wrap-reverse" {
+    @else if $value == "wrap-reverse" {
         $alt-value: multiple;
     }
 
@@ -224,15 +224,15 @@
         $alt-value: start;
     }
 
-    @elseif $value == "flex-end" {
+    @else if $value == "flex-end" {
         $alt-value: end;
     }
 
-    @elseif $value == "space-between" {
+    @else if $value == "space-between" {
         $alt-value: justify;
     }
 
-    @elseif $value == "space-around" {
+    @else if $value == "space-around" {
         $alt-value: center;
     }
 
@@ -257,7 +257,7 @@
         $alt-value: start;
     }    
 
-    @elseif $value == "flex-end" {
+    @else if $value == "flex-end" {
         $alt-value: end;
     }
 
@@ -280,7 +280,7 @@
         $value-2011: start;
     }    
 
-    @elseif $value == "flex-end" {
+    @else if $value == "flex-end" {
         $value-2011: end;
     }
 
@@ -300,15 +300,15 @@
         $value-2011: start;
     }    
 
-    @elseif $value == "flex-end" {
+    @else if $value == "flex-end" {
         $value-2011: end;
     }
 
-    @elseif $value == "space-between" {
+    @else if $value == "space-between" {
         $value-2011: justify;
     }
 
-    @elseif $value == "space-around" {
+    @else if $value == "space-around" {
         $value-2011: distribute;
     }
 

--- a/dist/helpers/_render-gradients.scss
+++ b/dist/helpers/_render-gradients.scss
@@ -16,11 +16,11 @@
   }
 
   @if $vendor {
-    $vendor-gradients: -#{$vendor}-#{$gradient-type}-gradient(#{$pre-spec} $gradients);
+    $vendor-gradients: "-#{$vendor}-#{$gradient-type}-gradient(#{$pre-spec} #{$gradients})";
   }
   @else if $vendor == false {
     $vendor-gradients: "#{$gradient-type}-gradient(#{$spec} #{$gradients})";
-    $vendor-gradients: unquote($vendor-gradients);
   }
+  $vendor-gradients: unquote($vendor-gradients);
   @return $vendor-gradients;
 }


### PR DESCRIPTION
- `_flex-box.scss`: `@elseif` is not standard syntax, it should be `@else if`
- `_render-gradients.scss`: should use quote string to concat strings and variables, if not, the sass-compiler will return like `-webkit-linear -gradient(…)`
