### PR TITLE
add $all-text-inputs-active variable

### DIFF
--- a/app/assets/stylesheets/addons/_html5-input-types.scss
+++ b/app/assets/stylesheets/addons/_html5-input-types.scss
@@ -32,12 +32,16 @@ $all-text-inputs-hover: assign-inputs($inputs-list, hover);
 //************************************************************************//
 $all-text-inputs-focus: assign-inputs($inputs-list, focus);
 
+// Active Pseudo-class
+//************************************************************************//
+$all-text-inputs-active: assign-inputs($inputs-list, active);
 
 
 // You must use interpolation on the variable:
 // #{$all-text-inputs}
 // #{$all-text-inputs-hover}
 // #{$all-text-inputs-focus}
+// #{$all-text-inputs-active}
 
 // Example
 //************************************************************************//


### PR DESCRIPTION
This is a really simple and straightforward addition.  It seems like we should have an 'active' variable set for all inputs similar to 'focus' or 'hover'.

Since active and focus do represent slightly different states on inputs, I think we should add this $all-text-inputs-active variable to the html5-input-types.
