### PR TITLE
Refactor hide-text mixin

### DIFF
--- a/app/assets/stylesheets/addons/_hide-text.scss
+++ b/app/assets/stylesheets/addons/_hide-text.scss
@@ -1,42 +1,27 @@
-@charset "UTF-8";
-
-/// An image replacement mixin. It is based off the
-/// [HTML5 Boilerplate image replacement](https://github.com/h5bp/html5-boilerplate/commit/aa0396eae757c9e03dda4e463fb0d4db5a5f82d7). This technique is an alternative to the `text-indent` technique and has
-/// [performance and other benefits](http://nicolasgallagher.com/another-css-image-replacement-technique/).
+/// Hides the text in an element, commonly used to show an image. Some elements will need block-level styles applied.
 ///
-/// @param {Value} $height [1em]
-///   A height declaration is required for this to function.
+/// @link http://zeldman.com/2012/03/01/replacing-the-9999px-hack-new-image-replacement
 ///
 /// @example scss - Usage
 ///   .element {
 ///     @include hide-text;
-///     background-image: url(logo.png);
 ///   }
 ///
 /// @example css - CSS Output
 ///   .element {
-///     height: 1em;
-///     line-height: 1.5;
 ///     overflow: hidden;
-///     background-image: url(logo.png);
+///     text-indent: 101%;
+///     white-space: nowrap;
 ///   }
 ///
-///   .element::before {
-///     content: "";
-///     display: block;
-///     width: 0;
-///     height: 100%;
-///   }
+/// @todo Remove height argument in v5.0.0
 
-@mixin hide-text($height: 1em) {
-  height: $height;
-  line-height: 1.5;
+@mixin hide-text($height: null) {
   overflow: hidden;
+  text-indent: 101%;
+  white-space: nowrap;
 
-  &::before {
-    content: "";
-    display: block;
-    height: 100%;
-    width: 0;
+  @if $height {
+    @warn "The `hide-text` mixin has changed and no longer requires a height. The height argument will no longer be accepted in v5.0.0";
   }
 }


### PR DESCRIPTION
Fixes #583

`text-indent: 101%` is used to prevent some typefaces from extending left into the visible area. 

- [ ] Update the docs with the requirement to use `display: block;` or `display: inline-block;` on the element using the mixin. ([PR](https://github.com/thoughtbot/bourbon/pull/627))

Credit to @HugoGiraudel for this suggestion