### PR TITLE
Restore IE8 support in clearfix mixin

### DIFF
--- a/app/assets/stylesheets/addons/_clearfix.scss
+++ b/app/assets/stylesheets/addons/_clearfix.scss
@@ -6,7 +6,7 @@
 // }
 
 @mixin clearfix {
-  &::after {
+  &:after {
     clear: both;
     content: "";
     display: table;


### PR DESCRIPTION
Using the single colon pseudo element you allow a better browser support.

This reference: http://caniuse.com/#feat=css-gencontent might be useful.