### PR TITLE
Fix sass 3.3 / libsass compatibility

### DIFF
--- a/app/assets/stylesheets/css3/_selection.scss
+++ b/app/assets/stylesheets/css3/_selection.scss
@@ -1,7 +1,7 @@
-@mixin selection {
+@mixin selection($for-parent: false) {
   $before-colons: "";
 
-  @if & {
+  @if $for-parent {
     $before-colons: "&"
   }
 


### PR DESCRIPTION
This reverts commit 96d29dd ("Simplify selection mixin") because it breaks compatibility with both sass 3.3 and libsass. Sass 3.3 should be compatible according to the gemspec. Fixes #615.

Error with sass 3.3.14:
```
ActionView::Template::Error (Invalid CSS after "  @if ": expected expression (e.g. 1px, bold), was "& {"
```