### PR TITLE
Clear up position add-on documentation

### DIFF
--- a/_includes/addons/position.html
+++ b/_includes/addons/position.html
@@ -3,19 +3,23 @@
     <h2 class="title">Position</h2>
     <a class="view-source" href="//github.com/thoughtbot/bourbon/blob/master/app/assets/stylesheets/addons/_position.scss">View source</a>
   </header>
-  <p>Shorthand notation for setting the position of elements in your page.</p>
-  <p>The first parameter is optional, with a default value of <code>relative</code>. The second parameter is a space delimited list of values that follow the standard CSS shorthand notation.</p>
-  <p>Note: null values will be ignored. In the example below, this means that selectors will not be generated for the right and bottom positions, while the top position is set to 0px.</p>
+  <p>A shorthand notation for positioning elements.</p>
+  <p>The first argument is optional and defaults to <code>relative</code>. The second argument is a space-delimited list of values for <code>top</code>, <code>right</code>, <code>bottom</code> and <code>left</code>; it follows the standard CSS shorthand notation.</p>
+  <p><strong>Note:</strong> <code>null</code> values will be ignored. In the example below, this means that selectors will <em>not</em> be generated for the <code>right</code> and <code>bottom</code> properties.</p>
 
-  <p>Instead of writing:</p>
 {% highlight scss %}
-position: relative;
-top: 0px;
-left: 100px;
+.element {
+  @include position(relative, 0 null null 10em);
+}
 {% endhighlight %}
 
-  <p>Your can write:</p>
-{% highlight scss %}
-@include position(relative, 0px null null 100px);
+<h3>CSS Output</h3>
+
+{% highlight css %}
+.element {
+  position: relative;
+  top: 0;
+  left: 10em;
+}
 {% endhighlight %}
 </article>


### PR DESCRIPTION
- Remove mention of pixels, because who uses those?!
- Remove the unit from the `0`, as our [style guide discourages doing this](https://github.com/thoughtbot/guides/tree/master/style/sass#formatting)