### PR TITLE
Add note about Sass's native @import, vs Sprockets directives

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,11 +72,7 @@ For command line help, visit our wiki page on Bourbon’s [command line interfac
   mv app/assets/stylesheets/application.css app/assets/stylesheets/application.scss
   ```
 
-4. Delete the Sprockets directive in `application.scss`:
-
-  ```scss
-  *= require_tree .
-  ```
+4. Delete all Sprockets directives in `application.scss` (`require`, `require_tree` and `require_self`), and use Sass's native `@import` instead.
 
 5. Import Bourbon at the beginning of `application.scss`. All additional stylesheets should be imported below Bourbon:
 


### PR DESCRIPTION
If someone is converting an existing application that uses CSS to Sass/Bourbon, it might be good to tell them about not using Sprockets directives.