### PR TITLE
Rename font-family to font-stacks

### DIFF
--- a/app/assets/stylesheets/_bourbon.scss
+++ b/app/assets/stylesheets/_bourbon.scss
@@ -71,7 +71,7 @@
 @import "addons/clearfix";
 @import "addons/directional-values";
 @import "addons/ellipsis";
-@import "addons/font-family";
+@import "addons/font-stacks";
 @import "addons/hide-text";
 @import "addons/html5-input-types";
 @import "addons/position";

--- a/app/assets/stylesheets/addons/_font-stacks.scss
+++ b/app/assets/stylesheets/addons/_font-stacks.scss
@@ -1,5 +1,31 @@
+@charset "UTF-8";
+
+/// Georgia font stack.
+///
+/// @type List
+
 $georgia: "Georgia", "Cambria", "Times New Roman", "Times", serif;
+
+/// Helvetica font stack.
+///
+/// @type List
+
 $helvetica: "Helvetica Neue", "Helvetica", "Roboto", "Arial", sans-serif;
+
+/// Lucida Grande font stack.
+///
+/// @type List
+
 $lucida-grande: "Lucida Grande", "Tahoma", "Verdana", "Arial", sans-serif;
+
+/// Monospace font stack.
+///
+/// @type List
+
 $monospace: "Bitstream Vera Sans Mono", "Consolas", "Courier", monospace;
+
+/// Verdana font stack.
+///
+/// @type List
+
 $verdana: "Verdana", "Geneva", sans-serif;


### PR DESCRIPTION
Minor thing: but our `font-family` variables aren’t really font families, they are font stacks. So this is renaming them to just that. Ya know, for like clarity and stuff.

- Add SassDoc

- [ ] Update docs ([PR](https://github.com/thoughtbot/bourbon/pull/645))