### PR TITLE
Revert back to old prefixer

### DIFF
--- a/app/assets/stylesheets/_bourbon-deprecated-upcoming.scss
+++ b/app/assets/stylesheets/_bourbon-deprecated-upcoming.scss
@@ -405,8 +405,7 @@
 }
 
 @mixin box-sizing($box) {
-  // content-box | border-box | inherit
-  @include prefixer(box-sizing, $box, webkit moz);
+  @include prefixer(box-sizing, $box, webkit moz spec);
 
   @warn "The box-sizing mixin is deprecated and will be removed in the next major version release. This property can now be used un-prefixed.";
 }

--- a/app/assets/stylesheets/addons/_prefixer.scss
+++ b/app/assets/stylesheets/addons/_prefixer.scss
@@ -23,18 +23,44 @@
 ///     border-radius: 10px;
 ///   }
 ///
-/// @require {variable} $global-prefixes
+/// @require {variable} $prefix-for-webkit
+/// @require {variable} $prefix-for-mozilla
+/// @require {variable} $prefix-for-microsoft
+/// @require {variable} $prefix-for-opera
+/// @require {variable} $prefix-for-spec
 
-@mixin prefixer($property, $value, $prefixes: ()) {
+@mixin prefixer($property, $value, $prefixes) {
   @each $prefix in $prefixes {
-    @if not map-has-key($global-prefixes, $prefix) {
-      @warn "Unrecognized prefix: `#{$prefix}`.";
-    }
-
-    @if map-get($global-prefixes, $prefix) {
-      #{"-" + $prefix + "-" + $property}: $value;
+    @if $prefix == webkit {
+      @if $prefix-for-webkit {
+        -webkit-#{$property}: $value;
+      }
+    } @else if $prefix == moz {
+      @if $prefix-for-mozilla {
+        -moz-#{$property}: $value;
+      }
+    } @else if $prefix == ms {
+      @if $prefix-for-microsoft {
+        -ms-#{$property}: $value;
+      }
+    } @else if $prefix == o {
+      @if $prefix-for-opera {
+        -o-#{$property}: $value;
+      }
+    } @else if $prefix == spec {
+      @if $prefix-for-spec {
+        #{$property}: $value;
+      }
+    } @else  {
+      @warn "Unrecognized prefix: #{$prefix}";
     }
   }
+}
 
-  #{$property}: $value;
+@mixin disable-prefix-for-all() {
+  $prefix-for-webkit:    false !global;
+  $prefix-for-mozilla:   false !global;
+  $prefix-for-microsoft: false !global;
+  $prefix-for-opera:     false !global;
+  $prefix-for-spec:      false !global;
 }

--- a/app/assets/stylesheets/css3/_animation.scss
+++ b/app/assets/stylesheets/css3/_animation.scss
@@ -2,42 +2,42 @@
 // Each of these mixins support comma separated lists of values, which allows different transitions for individual properties to be described in a single style rule. Each value in the list corresponds to the value at that same position in the other properties.
 
 @mixin animation($animations...) {
-  @include prefixer(animation, $animations, webkit moz);
+  @include prefixer(animation, $animations, webkit moz spec);
 }
 
 @mixin animation-name($names...) {
-  @include prefixer(animation-name, $names, webkit moz);
+  @include prefixer(animation-name, $names, webkit moz spec);
 }
 
 @mixin animation-duration($times...) {
-  @include prefixer(animation-duration, $times, webkit moz);
+  @include prefixer(animation-duration, $times, webkit moz spec);
 }
 
 @mixin animation-timing-function($motions...) {
-// ease | linear | ease-in | ease-out | ease-in-out
-  @include prefixer(animation-timing-function, $motions, webkit moz);
+  // ease | linear | ease-in | ease-out | ease-in-out
+  @include prefixer(animation-timing-function, $motions, webkit moz spec);
 }
 
 @mixin animation-iteration-count($values...) {
-// infinite | <number>
-  @include prefixer(animation-iteration-count, $values, webkit moz);
+  // infinite | <number>
+  @include prefixer(animation-iteration-count, $values, webkit moz spec);
 }
 
 @mixin animation-direction($directions...) {
-// normal | alternate
-  @include prefixer(animation-direction, $directions, webkit moz);
+  // normal | alternate
+  @include prefixer(animation-direction, $directions, webkit moz spec);
 }
 
 @mixin animation-play-state($states...) {
-// running | paused
-  @include prefixer(animation-play-state, $states, webkit moz);
+  // running | paused
+  @include prefixer(animation-play-state, $states, webkit moz spec);
 }
 
 @mixin animation-delay($times...) {
-  @include prefixer(animation-delay, $times, webkit moz);
+  @include prefixer(animation-delay, $times, webkit moz spec);
 }
 
 @mixin animation-fill-mode($modes...) {
-// none | forwards | backwards | both
-  @include prefixer(animation-fill-mode, $modes, webkit moz);
+  // none | forwards | backwards | both
+  @include prefixer(animation-fill-mode, $modes, webkit moz spec);
 }

--- a/app/assets/stylesheets/css3/_appearance.scss
+++ b/app/assets/stylesheets/css3/_appearance.scss
@@ -1,3 +1,3 @@
 @mixin appearance($value) {
-  @include prefixer(appearance, $value, webkit moz ms o);
+  @include prefixer(appearance, $value, webkit moz ms o spec);
 }

--- a/app/assets/stylesheets/css3/_backface-visibility.scss
+++ b/app/assets/stylesheets/css3/_backface-visibility.scss
@@ -1,3 +1,3 @@
 @mixin backface-visibility($visibility) {
-  @include prefixer(backface-visibility, $visibility, webkit);
+  @include prefixer(backface-visibility, $visibility, webkit spec);
 }

--- a/app/assets/stylesheets/css3/_calc.scss
+++ b/app/assets/stylesheets/css3/_calc.scss
@@ -1,6 +1,4 @@
 @mixin calc($property, $value) {
-  @if map-get($prefixes, webkit) {
-    #{$property}: -webkit-calc(#{$value});
-  }
+  #{$property}: -webkit-calc(#{$value});
   #{$property}: calc(#{$value});
 }

--- a/app/assets/stylesheets/css3/_columns.scss
+++ b/app/assets/stylesheets/css3/_columns.scss
@@ -1,47 +1,47 @@
 @mixin columns($arg: auto) {
-// <column-count> || <column-width>
-  @include prefixer(columns, $arg, webkit moz);
+  // <column-count> || <column-width>
+  @include prefixer(columns, $arg, webkit moz spec);
 }
 
 @mixin column-count($int: auto) {
-// auto || integer
-  @include prefixer(column-count, $int, webkit moz);
+  // auto || integer
+  @include prefixer(column-count, $int, webkit moz spec);
 }
 
 @mixin column-gap($length: normal) {
-// normal || length
-  @include prefixer(column-gap, $length, webkit moz);
+  // normal || length
+  @include prefixer(column-gap, $length, webkit moz spec);
 }
 
 @mixin column-fill($arg: auto) {
-// auto || length
-  @include prefixer(column-fill, $arg, webkit moz);
+  // auto || length
+  @include prefixer(column-fill, $arg, webkit moz spec);
 }
 
 @mixin column-rule($arg) {
-// <border-width> || <border-style> || <color>
-  @include prefixer(column-rule, $arg, webkit moz);
+  // <border-width> || <border-style> || <color>
+  @include prefixer(column-rule, $arg, webkit moz spec);
 }
 
 @mixin column-rule-color($color) {
-  @include prefixer(column-rule-color, $color, webkit moz);
+  @include prefixer(column-rule-color, $color, webkit moz spec);
 }
 
 @mixin column-rule-style($style: none) {
-// none | hidden | dashed | dotted | double | groove | inset | inset | outset | ridge | solid
-  @include prefixer(column-rule-style, $style, webkit moz);
+  // none | hidden | dashed | dotted | double | groove | inset | inset | outset | ridge | solid
+  @include prefixer(column-rule-style, $style, webkit moz spec);
 }
 
 @mixin column-rule-width ($width: none) {
-  @include prefixer(column-rule-width, $width, webkit moz);
+  @include prefixer(column-rule-width, $width, webkit moz spec);
 }
 
 @mixin column-span($arg: none) {
-// none || all
-  @include prefixer(column-span, $arg, webkit moz);
+  // none || all
+  @include prefixer(column-span, $arg, webkit moz spec);
 }
 
 @mixin column-width($length: auto) {
-// auto || length
-  @include prefixer(column-width, $length, webkit moz);
+  // auto || length
+  @include prefixer(column-width, $length, webkit moz spec);
 }

--- a/app/assets/stylesheets/css3/_filter.scss
+++ b/app/assets/stylesheets/css3/_filter.scss
@@ -1,5 +1,4 @@
 @mixin filter($function: none) {
-// <filter-function> [<filter-function]* | none
-  @include prefixer(filter, $function, webkit);
+  // <filter-function> [<filter-function]* | none
+  @include prefixer(filter, $function, webkit spec);
 }
-

--- a/app/assets/stylesheets/css3/_flex-box.scss
+++ b/app/assets/stylesheets/css3/_flex-box.scss
@@ -17,44 +17,44 @@
 
 @mixin box-orient($orient: inline-axis) {
 // horizontal|vertical|inline-axis|block-axis|inherit
-  @include prefixer(box-orient, $orient, webkit moz);
+  @include prefixer(box-orient, $orient, webkit moz spec);
 }
 
 @mixin box-pack($pack: start) {
 // start|end|center|justify
-  @include prefixer(box-pack, $pack, webkit moz);
+  @include prefixer(box-pack, $pack, webkit moz spec);
   -ms-flex-pack: $pack; // IE 10
 }
 
 @mixin box-align($align: stretch) {
 // start|end|center|baseline|stretch
-  @include prefixer(box-align, $align, webkit moz);
+  @include prefixer(box-align, $align, webkit moz spec);
   -ms-flex-align: $align; // IE 10
 }
 
 @mixin box-direction($direction: normal) {
 // normal|reverse|inherit
-  @include prefixer(box-direction, $direction, webkit moz);
+  @include prefixer(box-direction, $direction, webkit moz spec);
   -ms-flex-direction: $direction; // IE 10
 }
 
 @mixin box-lines($lines: single) {
 // single|multiple
-  @include prefixer(box-lines, $lines, webkit moz);
+  @include prefixer(box-lines, $lines, webkit moz spec);
 }
 
 @mixin box-ordinal-group($int: 1) {
-  @include prefixer(box-ordinal-group, $int, webkit moz);
+  @include prefixer(box-ordinal-group, $int, webkit moz spec);
   -ms-flex-order: $int; // IE 10
 }
 
 @mixin box-flex($value: 0) {
-  @include prefixer(box-flex, $value, webkit moz);
+  @include prefixer(box-flex, $value, webkit moz spec);
   -ms-flex: $value; // IE 10
 }
 
 @mixin box-flex-group($int: 1) {
-  @include prefixer(box-flex-group, $int, webkit moz);
+  @include prefixer(box-flex-group, $int, webkit moz spec);
 }
 
 // CSS3 Flexible Box Model and property defaults
@@ -76,9 +76,7 @@
     display: -moz-flex;
     display: -ms-flexbox; // 2011 (IE 10)
     display: flex;
-  }
-
-  @else if $value == "inline-flex" {
+  } @else if $value == "inline-flex" {
     display: -webkit-inline-box;
     display: -moz-inline-box;
     display: inline-box;
@@ -87,9 +85,7 @@
     display: -moz-inline-flex;
     display: -ms-inline-flexbox;
     display: inline-flex;
-  }
-
-  @else {
+  } @else {
     display: $value;
   }
 }
@@ -103,10 +99,10 @@
   $flex-grow: nth($value, 1);
 
   // 2009
-  @include prefixer(box-flex, $flex-grow, webkit moz);
+  @include prefixer(box-flex, $flex-grow, webkit moz spec);
 
   // 2011 (IE 10), 2012
-  @include prefixer(flex, $value, webkit moz ms);
+  @include prefixer(flex, $value, webkit moz ms spec);
 }
 
 // 2009 - box-orient ( horizontal | vertical | inline-axis | block-axis)
@@ -122,30 +118,24 @@
 
   @if $value == row {
     $value-2009: horizontal;
-  }
-
-  @else if $value == "row-reverse" {
+  } @else if $value == "row-reverse" {
     $value-2009: horizontal;
     $direction: reverse;
-  }
-
-  @else if $value == column {
+  } @else if $value == column {
     $value-2009: vertical;
-  }
-
-  @else if $value == "column-reverse" {
+  } @else if $value == "column-reverse" {
     $value-2009: vertical;
     $direction: reverse;
   }
 
   // 2009
-  @include prefixer(box-orient, $value-2009, webkit moz);
+  @include prefixer(box-orient, $value-2009, webkit moz spec);
   @if $direction == "reverse" {
-    @include prefixer(box-direction, $direction, webkit moz);
+    @include prefixer(box-direction, $direction, webkit moz spec);
   }
 
   // 2012
-  @include prefixer(flex-direction, $value, webkit moz);
+  @include prefixer(flex-direction, $value, webkit moz spec);
 
   // 2011 (IE 10)
   -ms-flex-direction: $value;
@@ -155,30 +145,25 @@
 // 2011 - flex-wrap (nowrap | wrap | wrap-reverse)
 // 2012 - flex-wrap (nowrap | wrap | wrap-reverse)
 @mixin flex-wrap($value: nowrap) {
-
   // Alt values
   $alt-value: $value;
   @if $value == nowrap {
     $alt-value: single;
-  }
-
-  @else if $value == wrap {
+  } @else if $value == wrap {
+    $alt-value: multiple;
+  } @else if $value == "wrap-reverse" {
     $alt-value: multiple;
   }
 
-  @else if $value == "wrap-reverse" {
-    $alt-value: multiple;
-  }
-
-  @include prefixer(box-lines, $alt-value, webkit moz);
-  @include prefixer(flex-wrap, $value, webkit moz ms);
+  @include prefixer(box-lines, $alt-value, webkit moz spec);
+  @include prefixer(flex-wrap, $value, webkit moz ms spec);
 }
 
 // 2009 - TODO: parse values into flex-direction/flex-wrap
 // 2011 - TODO: parse values into flex-direction/flex-wrap
 // 2012 - flex-flow (flex-direction || flex-wrap)
 @mixin flex-flow($value) {
-  @include prefixer(flex-flow, $value, webkit moz);
+  @include prefixer(flex-flow, $value, webkit moz spec);
 }
 
 // 2009 - box-ordinal-group (integer)
@@ -186,10 +171,10 @@
 // 2012 - order (integer)
 @mixin order($int: 0) {
   // 2009
-  @include prefixer(box-ordinal-group, $int, webkit moz);
+  @include prefixer(box-ordinal-group, $int, webkit moz spec);
 
   // 2012
-  @include prefixer(order, $int, webkit moz);
+  @include prefixer(order, $int, webkit moz spec);
 
   // 2011 (IE 10)
   -ms-flex-order: $int;
@@ -197,19 +182,19 @@
 
 // 2012 - flex-grow (number)
 @mixin flex-grow($number: 0) {
-  @include prefixer(flex-grow, $number, webkit moz);
+  @include prefixer(flex-grow, $number, webkit moz spec);
   -ms-flex-positive: $number;
 }
 
 // 2012 - flex-shrink (number)
 @mixin flex-shrink($number: 1) {
-  @include prefixer(flex-shrink, $number, webkit moz);
+  @include prefixer(flex-shrink, $number, webkit moz spec);
   -ms-flex-negative: $number;
 }
 
 // 2012 - flex-basis (number)
 @mixin flex-basis($width: auto) {
-  @include prefixer(flex-basis, $width, webkit moz);
+  @include prefixer(flex-basis, $width, webkit moz spec);
   -ms-flex-preferred-size: $width;
 }
 
@@ -222,25 +207,19 @@
   $alt-value: $value;
   @if $value == "flex-start" {
     $alt-value: start;
-  }
-
-  @else if $value == "flex-end" {
+  } @else if $value == "flex-end" {
     $alt-value: end;
-  }
-
-  @else if $value == "space-between" {
+  } @else if $value == "space-between" {
     $alt-value: justify;
-  }
-
-  @else if $value == "space-around" {
+  } @else if $value == "space-around" {
     $alt-value: distribute;
   }
 
   // 2009
-  @include prefixer(box-pack, $alt-value, webkit moz);
+  @include prefixer(box-pack, $alt-value, webkit moz spec);
 
   // 2012
-  @include prefixer(justify-content, $value, webkit moz ms o);
+  @include prefixer(justify-content, $value, webkit moz ms o spec);
 
   // 2011 (IE 10)
   -ms-flex-pack: $alt-value;
@@ -255,17 +234,15 @@
 
   @if $value == "flex-start" {
     $alt-value: start;
-  }
-
-  @else if $value == "flex-end" {
+  } @else if $value == "flex-end" {
     $alt-value: end;
   }
 
   // 2009
-  @include prefixer(box-align, $alt-value, webkit moz);
+  @include prefixer(box-align, $alt-value, webkit moz spec);
 
   // 2012
-  @include prefixer(align-items, $value, webkit moz ms o);
+  @include prefixer(align-items, $value, webkit moz ms o spec);
 
   // 2011 (IE 10)
   -ms-flex-align: $alt-value;
@@ -278,14 +255,12 @@
   $value-2011: $value;
   @if $value == "flex-start" {
     $value-2011: start;
-  }
-
-  @else if $value == "flex-end" {
+  } @else if $value == "flex-end" {
     $value-2011: end;
   }
 
   // 2012
-  @include prefixer(align-self, $value, webkit moz);
+  @include prefixer(align-self, $value, webkit moz spec);
 
   // 2011 (IE 10)
   -ms-flex-item-align: $value-2011;
@@ -298,22 +273,16 @@
   $value-2011: $value;
   @if $value == "flex-start" {
     $value-2011: start;
-  }
-
-  @else if $value == "flex-end" {
+  } @else if $value == "flex-end" {
     $value-2011: end;
-  }
-
-  @else if $value == "space-between" {
+  } @else if $value == "space-between" {
     $value-2011: justify;
-  }
-
-  @else if $value == "space-around" {
+  } @else if $value == "space-around" {
     $value-2011: distribute;
   }
 
   // 2012
-  @include prefixer(align-content, $value, webkit moz);
+  @include prefixer(align-content, $value, webkit moz spec);
 
   // 2011 (IE 10)
   -ms-flex-line-pack: $value-2011;

--- a/app/assets/stylesheets/css3/_font-feature-settings.scss
+++ b/app/assets/stylesheets/css3/_font-feature-settings.scss
@@ -1,10 +1,4 @@
-// Font feature settings mixin and property default.
-// Examples: @include font-feature-settings("liga");
-//           @include font-feature-settings("lnum" false);
-//           @include font-feature-settings("pnum" 1, "kern" 0);
-//           @include font-feature-settings("ss01", "ss02");
-
 @mixin font-feature-settings($settings...) {
   @if length($settings) == 0 { $settings: none; }
-  @include prefixer(font-feature-settings, $settings, webkit moz ms);
+  @include prefixer(font-feature-settings, $settings, webkit moz ms spec);
 }

--- a/app/assets/stylesheets/css3/_hyphens.scss
+++ b/app/assets/stylesheets/css3/_hyphens.scss
@@ -1,4 +1,4 @@
 @mixin hyphens($hyphenation: none) {
-// none | manual | auto
-  @include prefixer(hyphens, $hyphenation, webkit moz ms);
+  // none | manual | auto
+  @include prefixer(hyphens, $hyphenation, webkit moz ms spec);
 }

--- a/app/assets/stylesheets/css3/_keyframes.scss
+++ b/app/assets/stylesheets/css3/_keyframes.scss
@@ -1,23 +1,36 @@
-// Adds keyframes blocks for supported prefixes, removing redundant prefixes in the block’s content
+// Adds keyframes blocks for supported prefixes, removing redundant prefixes in the block's content
 @mixin keyframes($name) {
-  $original-prefix-for-webkit:    map-get($prefixes, webkit);
-  $original-prefix-for-mozilla:   map-get($prefixes, moz);
-  $original-prefix-for-microsoft: map-get($prefixes, ms);
-  $original-prefix-for-opera:     map-get($prefixes, o);
+  $original-prefix-for-webkit:    $prefix-for-webkit;
+  $original-prefix-for-mozilla:   $prefix-for-mozilla;
+  $original-prefix-for-microsoft: $prefix-for-microsoft;
+  $original-prefix-for-opera:     $prefix-for-opera;
+  $original-prefix-for-spec:      $prefix-for-spec;
 
-  @if map-get($prefixes, webkit) == true {
+  @if $original-prefix-for-webkit {
+    @include disable-prefix-for-all();
+    $prefix-for-webkit: true !global;
     @-webkit-keyframes #{$name} {
       @content;
     }
   }
 
-  @if map-get($prefixes, moz) == true {
+  @if $original-prefix-for-mozilla {
+    @include disable-prefix-for-all();
+    $prefix-for-mozilla: true !global;
     @-moz-keyframes #{$name} {
       @content;
     }
   }
 
-  @keyframes #{$name} {
-    @content;
+  $prefix-for-webkit:    $original-prefix-for-webkit    !global;
+  $prefix-for-mozilla:   $original-prefix-for-mozilla   !global;
+  $prefix-for-microsoft: $original-prefix-for-microsoft !global;
+  $prefix-for-opera:     $original-prefix-for-opera     !global;
+  $prefix-for-spec:      $original-prefix-for-spec      !global;
+
+  @if $original-prefix-for-spec {
+    @keyframes #{$name} {
+      @content;
+    }
   }
 }

--- a/app/assets/stylesheets/css3/_perspective.scss
+++ b/app/assets/stylesheets/css3/_perspective.scss
@@ -1,8 +1,8 @@
 @mixin perspective($depth: none) {
-// none | <length>
-  @include prefixer(perspective, $depth, webkit moz);
+  // none | <length>
+  @include prefixer(perspective, $depth, webkit moz spec);
 }
 
 @mixin perspective-origin($value: 50% 50%) {
-  @include prefixer(perspective-origin, $value, webkit moz);
+  @include prefixer(perspective-origin, $value, webkit moz spec);
 }

--- a/app/assets/stylesheets/css3/_transform.scss
+++ b/app/assets/stylesheets/css3/_transform.scss
@@ -1,15 +1,15 @@
 @mixin transform($property: none) {
-// none | <transform-function>
-  @include prefixer(transform, $property, webkit moz ms o);
+  // none | <transform-function>
+  @include prefixer(transform, $property, webkit moz ms o spec);
 }
 
 @mixin transform-origin($axes: 50%) {
-// x-axis - left | center | right  | length | %
-// y-axis - top  | center | bottom | length | %
-// z-axis -                          length
-  @include prefixer(transform-origin, $axes, webkit moz ms o);
+  // x-axis - left | center | right  | length | %
+  // y-axis - top  | center | bottom | length | %
+  // z-axis -                          length
+  @include prefixer(transform-origin, $axes, webkit moz ms o spec);
 }
 
-@mixin transform-style ($style: flat) {
-  @include prefixer(transform-style, $style, webkit moz ms o);
+@mixin transform-style($style: flat) {
+  @include prefixer(transform-style, $style, webkit moz ms o spec);
 }

--- a/app/assets/stylesheets/css3/_transition.scss
+++ b/app/assets/stylesheets/css3/_transition.scss
@@ -30,10 +30,7 @@
       $webkit: append($webkit, $list1);
       $moz:    append($moz,    $list2);
       $spec:   append($spec,   $list3);
-    }
-
-    // Create lists for non-prefixed transition properties
-    @else {
+    } @else {
       $webkit: append($webkit, $list, comma);
       $moz:    append($moz,    $list, comma);
       $spec:   append($spec,   $list, comma);
@@ -44,15 +41,12 @@
     -webkit-transition: $webkit;
        -moz-transition: $moz;
             transition: $spec;
-  }
-  @else {
+  } @else {
     @if length($properties) >= 1 {
-      @include prefixer(transition, $properties, webkit moz);
-    }
-
-    @else {
+      @include prefixer(transition, $properties, webkit moz spec);
+    } @else {
       $properties: all 0.15s ease-out 0s;
-      @include prefixer(transition, $properties, webkit moz);
+      @include prefixer(transition, $properties, webkit moz spec);
     }
   }
 }
@@ -64,14 +58,14 @@
 }
 
 @mixin transition-duration($times...) {
-  @include prefixer(transition-duration, $times, webkit moz);
+  @include prefixer(transition-duration, $times, webkit moz spec);
 }
 
 @mixin transition-timing-function($motions...) {
-// ease | linear | ease-in | ease-out | ease-in-out | cubic-bezier()
-  @include prefixer(transition-timing-function, $motions, webkit moz);
+  // ease | linear | ease-in | ease-out | ease-in-out | cubic-bezier()
+  @include prefixer(transition-timing-function, $motions, webkit moz spec);
 }
 
 @mixin transition-delay($times...) {
-  @include prefixer(transition-delay, $times, webkit moz);
+  @include prefixer(transition-delay, $times, webkit moz spec);
 }

--- a/app/assets/stylesheets/css3/_user-select.scss
+++ b/app/assets/stylesheets/css3/_user-select.scss
@@ -1,3 +1,3 @@
-@mixin user-select($arg: none) {
-  @include prefixer(user-select, $arg, webkit moz ms);
+@mixin user-select($value: none) {
+  @include prefixer(user-select, $value, webkit moz ms spec);
 }

--- a/app/assets/stylesheets/settings/_prefixer.scss
+++ b/app/assets/stylesheets/settings/_prefixer.scss
@@ -1,12 +1,9 @@
 @charset "UTF-8";
 
-/// A global setting to enable or disable vendor prefixes
-///
-/// @type Map
+/// Global variables to enable or disable vendor prefixes
 
-$global-prefixes: (
-  "webkit": true,
-  "moz": true,
-  "ms": true,
-  "o": true
-) !default;
+$prefix-for-webkit:    true !default;
+$prefix-for-mozilla:   true !default;
+$prefix-for-microsoft: true !default;
+$prefix-for-opera:     true !default;
+$prefix-for-spec:      true !default;


### PR DESCRIPTION
This was a breaking change and we can't offer a fallback. We can update the prefixer when we move to v5.0.0