### PR TITLE
Add test for px-to-em()

### DIFF
--- a/spec/bourbon/functions/px_to_em_spec.rb
+++ b/spec/bourbon/functions/px_to_em_spec.rb
@@ -1,0 +1,31 @@
+require "spec_helper"
+
+describe "px-to-em" do
+  before(:all) do
+    ParserSupport.parse_file("functions/px-to-em")
+  end
+
+  context "called with unitless integer" do
+    it "outputs ems" do
+      expect(".unitless").to have_rule("font-size: 0.75em")
+    end
+  end
+
+  context "called with unitless integer and base" do
+    it "outputs ems" do
+      expect(".unitless-with-base").to have_rule("font-size: 0.66667em")
+    end
+  end
+
+  context "called with px" do
+    it "outputs ems" do
+      expect(".px").to have_rule("font-size: 1em")
+    end
+  end
+
+  context "called with px" do
+    it "outputs ems" do
+      expect(".px-with-base").to have_rule("font-size: 1.5em")
+    end
+  end
+end

--- a/spec/fixtures/functions/px-to-em.scss
+++ b/spec/fixtures/functions/px-to-em.scss
@@ -1,0 +1,17 @@
+@import "setup";
+
+.unitless {
+  font-size: em(12);
+}
+
+.unitless-with-base {
+  font-size: em(10, 15);
+}
+
+.px {
+  font-size: em(16px);
+}
+
+.px-with-base {
+  font-size: em(15px, 10px);
+}


### PR DESCRIPTION
I would like this test to be more robust, but the `em()` function errors when you give it anything other than px anyway.