### PR TITLE
When test fails, output css that was found instead

### DIFF
--- a/spec/support/matchers/have_rule.rb
+++ b/spec/support/matchers/have_rule.rb
@@ -8,7 +8,9 @@ RSpec::Matchers.define :have_rule do |expected|
     if @rules.empty?
       %{no CSS for selector #{selector} were found}
     else
-      %{expected selector #{selector} to have CSS rule "#{expected}"}
+      rules = @rules.join("; ")
+      %{Expected selector #{selector} to have CSS rule "#{expected}".
+        Had "#{rules}".}
     end
   end
 


### PR DESCRIPTION
Makes testing a little more friendly by showing you more than just pass/fail.