### PR TITLE
Restores app/ for npm installations

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,6 @@
 .gitignore
 .hound.yml
 _site
-app/
 bin/
 bourbon.gemspec
 bower.json


### PR DESCRIPTION
Right now, installing through npm doesn’t actually include Bourbon. The files were being ignored from when `dist/` was still part of the package.