### PR TITLE
Made clearfix addon an extend instead of an mixin

### DIFF
--- a/app/assets/stylesheets/addons/_clearfix.scss
+++ b/app/assets/stylesheets/addons/_clearfix.scss
@@ -6,7 +6,7 @@
 ///
 /// @example scss - Usage
 ///   .element {
-///     @include clearfix;
+///     @extend %clearfix;
 ///   }
 ///
 /// @example css - CSS Output
@@ -16,10 +16,15 @@
 ///     display: table;
 ///   }
 
-@mixin clearfix {
+%clearfix {
   &::after {
     clear: both;
     content: "";
     display: table;
   }
+}
+
+// Fallback, deprecate at some point?
+@mixin clearfix {
+  @extend %clearfix
 }

--- a/app/assets/stylesheets/addons/_clearfix.scss
+++ b/app/assets/stylesheets/addons/_clearfix.scss
@@ -26,5 +26,5 @@
 
 // Fallback, deprecate at some point?
 @mixin clearfix {
-  @extend %clearfix
+  @extend %clearfix;
 }


### PR DESCRIPTION
The clearfix addon requires no arguments so there's no need to implement it as a mixin. Implementing it as an extend will result in less CSS output (far less, depending on usage count). The proposed change includes a fallback as well.

A more in-depth explanation can be found here: http://blog.teamtreehouse.com/a-better-clearfix-with-sass