### PR TITLE
Add `.sass-cache` to `.npmignore`

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -12,3 +12,4 @@ lib/
 Rakefile
 sache.json
 spec/
+.sass-cache


### PR DESCRIPTION
I just installed bourbon via npm and noticed that the package contained a `.sass-cache` directory. To prevent this from being uploaded in the future, I added it to the `.npmignore` file.