### PR TITLE
Fix 'Undefined variable: "$em-base"'

### DIFF
--- a/app/assets/stylesheets/functions/_modular-scale.scss
+++ b/app/assets/stylesheets/functions/_modular-scale.scss
@@ -1,3 +1,5 @@
+@import "../settings/px-to-em";
+
 // Scaling Variables
 $golden:           1.618;
 $minor-second:     1.067;


### PR DESCRIPTION
Before this patch:

```bash
$ scss app/assets/stylesheets/functions/_modular-scale.scss
Error: Undefined variable: "$em-base".
        on line 21 of app/assets/stylesheets/functions/_modular-scale.scss
  Use --trace for backtrace.
```

And after:

```bash
$ scss app/assets/stylesheets/functions/_modular-scale.scss
$ echo $?
0
```