### PR TITLE
Sibling count mixin

### DIFF
--- a/app/assets/stylesheets/_bourbon.scss
+++ b/app/assets/stylesheets/_bourbon.scss
@@ -83,5 +83,6 @@
 @import "addons/timing-functions";
 @import "addons/triangle";
 @import "addons/word-wrap";
+@import "addons/sibling-count";
 
 @import "bourbon-deprecated-upcoming";

--- a/app/assets/stylesheets/addons/_sibling-count.scss
+++ b/app/assets/stylesheets/addons/_sibling-count.scss
@@ -13,13 +13,13 @@
 ///
 /// @example scss - Usage
 ///   ul.navbar li {
-///     @include sibling-count(1) { /* applies if total siblings == 1 */
+///     @include sibling-count(1) {
 ///       color: blue;
 ///     }
-///     @include sibling-count(2, $repeat: true) { /* applies if total siblings == 2n for any n */
+///     @include sibling-count(2, $repeat: true) {
 ///       color: green;
 ///     }
-///     @include sibling-count(3, $repeat: true, $offset: 1) { /* applies if total siblings == 3n+1 for any n */
+///     @include sibling-count(3, $repeat: true, $offset: 1) {
 ///       color: red;
 ///     }
 ///   }
@@ -39,7 +39,7 @@
 ///     color: red; }
 
 @mixin sibling-count($count, $repeat: false, $offset: 0) {
-  $prefix: '';
+  $prefix: "";
   $mod: $count+1;
 
   @if $repeat {

--- a/app/assets/stylesheets/addons/_sibling-count.scss
+++ b/app/assets/stylesheets/addons/_sibling-count.scss
@@ -2,36 +2,53 @@
 
 /// Makes it easy to apply styles to all siblings in a group based on total number of siblings.
 ///
-/// @param {Number} $n
-///   Apply nested styles if there are this many siblings
+/// @param {Number} $count
+///   Apply nested styles if there are this many siblings.
+///
+/// @param {Boolean} $repeat
+///   Apply nested styles if number of siblings is a multiple of `$count`.
+///
+/// @param {Number} $offset
+///   Apply nested styles if number of siblings is a multiple of `$count` plus this.
 ///
 /// @example scss - Usage
 ///   ul.navbar li {
-///     color: white;
-///     @include sibling-count(1) {
+///     @include sibling-count(1) { /* applies if total siblings == 1 */
 ///       color: blue;
 ///     }
-///     @include sibling-count(2) {
+///     @include sibling-count(2, $repeat: true) { /* applies if total siblings == 2n for any n */
 ///       color: green;
 ///     }
-///     @include sibling-count(3) {
+///     @include sibling-count(3, $repeat: true, $offset: 1) { /* applies if total siblings == 3n+1 for any n */
 ///       color: red;
 ///     }
 ///   }
 ///
 /// @example css - CSS Output
-///   ul.navbar li { color: white; }
-///   ul.navbar li:nth-child(1):nth-last-child(1) { color: blue; }
-///   ul.navbar li:nth-child(1):nth-last-child(2) { color: green; }
-///   ul.navbar li:nth-child(2):nth-last-child(1) { color: green; }
-///   ul.navbar li:nth-child(1):nth-last-child(3) { color: red; }
-///   ul.navbar li:nth-child(2):nth-last-child(2) { color: red; }
-///   ul.navbar li:nth-child(3):nth-last-child(1) { color: red; }
+///   ul.navbar li:nth-child(1):nth-last-child(1) {
+///     color: blue; }
+///   ul.navbar li:nth-child(2n+1):nth-last-child(2n+0) {
+///     color: green; }
+///   ul.navbar li:nth-child(2n+2):nth-last-child(2n+1) {
+///     color: green; }
+///   ul.navbar li:nth-child(3n+1):nth-last-child(3n+1) {
+///     color: red; }
+///   ul.navbar li:nth-child(3n+2):nth-last-child(3n+0) {
+///     color: red; }
+///   ul.navbar li:nth-child(3n+3):nth-last-child(3n+2) {
+///     color: red; }
 
+@mixin sibling-count($count, $repeat: false, $offset: 0) {
+  $prefix: '';
+  $mod: $count+1;
 
-@mixin sibling-count($n) {
-  @for $i from 0 to $n {
-    &:nth-child(#{$i + 1}):nth-last-child(#{$n - $i}) {
+  @if $repeat {
+    $prefix: "#{$count}n+";
+    $mod: $count;
+  }
+
+  @for $i from 0 to $count {
+    &:nth-child(#{$prefix}#{$i + 1}):nth-last-child(#{$prefix}#{($count - $i + $offset) % $mod}) {
       @content;
     }
   }

--- a/app/assets/stylesheets/addons/_sibling-count.scss
+++ b/app/assets/stylesheets/addons/_sibling-count.scss
@@ -1,0 +1,38 @@
+@charset "UTF-8";
+
+/// Makes it easy to apply styles to all siblings in a group based on total number of siblings.
+///
+/// @param {Number} $n
+///   Apply nested styles if there are this many siblings
+///
+/// @example scss - Usage
+///   ul.navbar li {
+///     color: white;
+///     @include sibling-count(1) {
+///       color: blue;
+///     }
+///     @include sibling-count(2) {
+///       color: green;
+///     }
+///     @include sibling-count(3) {
+///       color: red;
+///     }
+///   }
+///
+/// @example css - CSS Output
+///   ul.navbar li { color: white; }
+///   ul.navbar li:nth-child(1):nth-last-child(1) { color: blue; }
+///   ul.navbar li:nth-child(1):nth-last-child(2) { color: green; }
+///   ul.navbar li:nth-child(2):nth-last-child(1) { color: green; }
+///   ul.navbar li:nth-child(1):nth-last-child(3) { color: red; }
+///   ul.navbar li:nth-child(2):nth-last-child(2) { color: red; }
+///   ul.navbar li:nth-child(3):nth-last-child(1) { color: red; }
+
+
+@mixin sibling-count($n) {
+  @for $i from 0 to $n {
+    &:nth-child(#{$i + 1}):nth-last-child(#{$n - $i}) {
+      @content;
+    }
+  }
+}

--- a/spec/bourbon/addons/sibling_count_spec.rb
+++ b/spec/bourbon/addons/sibling_count_spec.rb
@@ -7,28 +7,28 @@ describe "sibling-count" do
 
   context "called with a number" do
     it "applies styles to elements with specific numbers of siblings" do
-      rule = "color: white"
+      rule = "color: #ffffff"
 
-      expect(".color-varies-by-sibling-count:nth-child(1):nth-last-child(1)").to have_rule(rule)
+      expect("li:nth-child(1):nth-last-child(1)").to have_rule(rule)
     end
   end
 
   context "called with a multiple" do
     it "applies styles to elements with specific multiples of siblings" do
-      rule = "color: gray"
+      rule = "color: #808080"
 
-      expect(".color-varies-by-sibling-count:nth-child(2n+1):nth-last-child(2n+0)").to have_rule(rule)
-      expect(".color-varies-by-sibling-count:nth-child(2n+2):nth-last-child(2n+1)").to have_rule(rule)
+      expect("li:nth-child(2n+1):nth-last-child(2n+0)").to have_rule(rule)
+      expect("li:nth-child(2n+2):nth-last-child(2n+1)").to have_rule(rule)
     end
   end
 
   context "called with a multiple and an offset" do
-    it "applies styles to elements where number of siblings % multiple == offset" do
-      rule = "color: black"
+    it "applies styles when number of siblings % multiple == offset" do
+      rule = "color: #000000"
 
-      expect(".color-varies-by-sibling-count:nth-child(3n+1):nth-last-child(3n+1)").to have_rule(rule)
-      expect(".color-varies-by-sibling-count:nth-child(3n+2):nth-last-child(3n+0)").to have_rule(rule)
-      expect(".color-varies-by-sibling-count:nth-child(3n+3):nth-last-child(3n+2)").to have_rule(rule)
+      expect("li:nth-child(3n+1):nth-last-child(3n+1)").to have_rule(rule)
+      expect("li:nth-child(3n+2):nth-last-child(3n+0)").to have_rule(rule)
+      expect("li:nth-child(3n+3):nth-last-child(3n+2)").to have_rule(rule)
     end
   end
 end

--- a/spec/bourbon/addons/sibling_count_spec.rb
+++ b/spec/bourbon/addons/sibling_count_spec.rb
@@ -1,0 +1,34 @@
+require "spec_helper"
+
+describe "sibling-count" do
+  before(:all) do
+    ParserSupport.parse_file("addons/sibling-count")
+  end
+
+  context "called with a number" do
+    it "applies styles to elements with specific numbers of siblings" do
+      rule = "color: white"
+
+      expect(".color-varies-by-sibling-count:nth-child(1):nth-last-child(1)").to have_rule(rule)
+    end
+  end
+
+  context "called with a multiple" do
+    it "applies styles to elements with specific multiples of siblings" do
+      rule = "color: gray"
+
+      expect(".color-varies-by-sibling-count:nth-child(2n+1):nth-last-child(2n+0)").to have_rule(rule)
+      expect(".color-varies-by-sibling-count:nth-child(2n+2):nth-last-child(2n+1)").to have_rule(rule)
+    end
+  end
+
+  context "called with a multiple and an offset" do
+    it "applies styles to elements where number of siblings % multiple == offset" do
+      rule = "color: black"
+
+      expect(".color-varies-by-sibling-count:nth-child(3n+1):nth-last-child(3n+1)").to have_rule(rule)
+      expect(".color-varies-by-sibling-count:nth-child(3n+2):nth-last-child(3n+0)").to have_rule(rule)
+      expect(".color-varies-by-sibling-count:nth-child(3n+3):nth-last-child(3n+2)").to have_rule(rule)
+    end
+  end
+end

--- a/spec/fixtures/addons/sibling-count.scss
+++ b/spec/fixtures/addons/sibling-count.scss
@@ -1,0 +1,18 @@
+@import "setup";
+
+.color-varies-by-sibling-count {
+  /* applies when there is exactly one child */
+  @include sibling-count(1) {
+    color: white;
+  }
+
+  /* applies when there are 2, 4, 6, 8,... children */
+  @include sibling-count(2, true) {
+    color: gray;
+  }
+
+  /* applies when there are 1, 4, 7, 10,... children */
+  @include sibling-count(3, true, 1) {
+    color: black;
+  }
+}

--- a/spec/fixtures/addons/sibling-count.scss
+++ b/spec/fixtures/addons/sibling-count.scss
@@ -1,18 +1,18 @@
 @import "setup";
 
-.color-varies-by-sibling-count {
-  /* applies when there is exactly one child */
+li {
+  // applies when there is exactly one child
   @include sibling-count(1) {
-    color: white;
+    color: #ffffff;
   }
 
-  /* applies when there are 2, 4, 6, 8,... children */
+  // applies when there are 2, 4, 6, 8,... children
   @include sibling-count(2, true) {
-    color: gray;
+    color: #808080;
   }
 
-  /* applies when there are 1, 4, 7, 10,... children */
+  // applies when there are 1, 4, 7, 10,... children
   @include sibling-count(3, true, 1) {
-    color: black;
+    color: #000000;
   }
 }


### PR DESCRIPTION
Following [these](http://stackoverflow.com/questions/8720931/can-css-detect-the-number-of-children-an-element-has) [posts](http://lea.verou.me/2011/01/styling-children-based-on-their-number-with-css3/), I wrote this mixin for styles specific to the number of children (or multiples of the number of children) of a parent element.

It's had enough applications in the work I've done so far that it seems like it might be generally useful to have in a mixin library like Bourbon.