### PR TITLE
Add input without type to text input list.

### DIFF
--- a/app/assets/stylesheets/addons/_text-inputs.scss
+++ b/app/assets/stylesheets/addons/_text-inputs.scss
@@ -104,6 +104,7 @@ $text-inputs-list: 'input[type="color"]',
                    'input[type="time"]',
                    'input[type="url"]',
                    'input[type="week"]',
+                   'input:not([type])',
                    'textarea';
 
 $all-text-inputs:        assign-inputs($text-inputs-list);

--- a/spec/bourbon/addons/text_inputs_spec.rb
+++ b/spec/bourbon/addons/text_inputs_spec.rb
@@ -19,6 +19,7 @@ describe "text-inputs" do
       input[type="time"]
       input[type="url"]
       input[type="week"]
+      input:not([type])
       textarea
     )
   end


### PR DESCRIPTION
The `type` attribute is optional and defaults to `"text"`. Therefore an input without `type` should be considered a text input.