### PR TITLE
Require all partials for Bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "bourbon",
   "description": "A simple and lightweight mixin library for Sass.",
   "version": "4.2.3",
-  "main": "app/assets/stylesheets/_bourbon.scss",
+  "main": "app/assets/stylesheets/*",
   "license": "MIT",
   "ignore": [
     "**/.*",

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "bourbon",
   "description": "A simple and lightweight mixin library for Sass.",
   "version": "4.2.3",
-  "main": "app/assets/stylesheets/*",
+  "main": "app/assets/stylesheets/**/*",
   "license": "MIT",
   "ignore": [
     "**/.*",


### PR DESCRIPTION
By listing all the required mixins in the bower `main` attribute it allows tools like [main-bower-files](https://github.com/ck86/main-bower-files) to extract whats needed for a build. This is how other popular libraries such as [font-awesome](https://github.com/FortAwesome/Font-Awesome/blob/master/bower.json) list their dependencies in their bower.json