### PR TITLE
Add support to @font-face local references

### DIFF
--- a/app/assets/stylesheets/css3/_font-face.scss
+++ b/app/assets/stylesheets/css3/_font-face.scss
@@ -4,7 +4,8 @@
   $weight: normal,
   $style: normal,
   $asset-pipeline: $asset-pipeline,
-  $file-formats: eot woff2 woff ttf svg) {
+  $file-formats: eot woff2 woff ttf svg,
+  $local-references: ()) {
 
   $font-url-prefix: font-url-prefixer($asset-pipeline);
 
@@ -18,7 +19,8 @@
       $file-path,
       $asset-pipeline,
       $file-formats,
-      $font-url-prefix
+      $font-url-prefix,
+      $local-references
     );
   }
 }

--- a/app/assets/stylesheets/helpers/_font-source-declaration.scss
+++ b/app/assets/stylesheets/helpers/_font-source-declaration.scss
@@ -14,7 +14,8 @@
   $file-path,
   $asset-pipeline,
   $file-formats,
-  $font-url) {
+  $font-url,
+  $local-references) {
 
   $src: ();
 
@@ -25,6 +26,10 @@
     ttf:   "#{$file-path}.ttf" format("truetype"),
     svg:   "#{$file-path}.svg##{$font-family}" format("svg")
   );
+
+  @each $local-reference in $local-references {
+    $src: append($src, local($local-reference), comma);
+  }
 
   @each $key, $values in $formats-map {
     @if contains($file-formats, $key) {

--- a/spec/bourbon/helpers/font_source_declaration_spec.rb
+++ b/spec/bourbon/helpers/font_source_declaration_spec.rb
@@ -8,10 +8,10 @@ describe "font-source-declaration" do
   context "called with pipeline" do
     it "returns pipeline path" do
       rule = 'src: font-url("b.eot?#iefix") format("embedded-opentype"), ' +
-             'font-url("b.woff2") format("woff2"), ' +
-             'font-url("b.woff") format("woff"), ' +
-             'font-url("b.ttf") format("truetype"), ' +
-             'font-url("b.svg#a") format("svg")'
+        'font-url("b.woff2") format("woff2"), ' +
+        'font-url("b.woff") format("woff"), ' +
+        'font-url("b.ttf") format("truetype"), ' +
+        'font-url("b.svg#a") format("svg")'
       expect(".has-pipeline").to have_rule(rule)
     end
   end
@@ -19,11 +19,24 @@ describe "font-source-declaration" do
   context "called with no pipeline" do
     it "does not return pipeline path" do
       rule = 'src: url("b.eot?#iefix") format("embedded-opentype"), ' +
-             'url("b.woff2") format("woff2"), ' +
-             'url("b.woff") format("woff"), ' +
-             'url("b.ttf") format("truetype"), ' +
-             'url("b.svg#a") format("svg")'
+        'url("b.woff2") format("woff2"), ' +
+        'url("b.woff") format("woff"), ' +
+        'url("b.ttf") format("truetype"), ' +
+        'url("b.svg#a") format("svg")'
       expect(".no-pipeline").to have_rule(rule)
+    end
+  end
+
+  context "called with local font references" do
+    it "includes local references" do
+      rule = 'src: local("FontA"), ' +
+        'local("Font A"), ' +
+        'url("b.eot?#iefix") format("embedded-opentype"), ' +
+        'url("b.woff2") format("woff2"), ' +
+        'url("b.woff") format("woff"), ' +
+        'url("b.ttf") format("truetype"), ' +
+        'url("b.svg#a") format("svg")'
+      expect(".font-with-local-references").to have_rule(rule)
     end
   end
 end

--- a/spec/fixtures/helpers/font-source-declaration.scss
+++ b/spec/fixtures/helpers/font-source-declaration.scss
@@ -2,9 +2,13 @@
 $file-formats: eot woff2 woff ttf svg;
 
 .has-pipeline {
-  src: font-source-declaration("a", "b", true, $file-formats, "/c");
+  src: font-source-declaration("a", "b", true, $file-formats, "/c", ());
 }
 
 .no-pipeline {
-  src: font-source-declaration("a", "b", false, $file-formats, "/c");
+  src: font-source-declaration("a", "b", false, $file-formats, "/c", ());
+}
+
+.font-with-local-references {
+  src: font-source-declaration("a", "b", false, $file-formats, "/c", $local-references: "FontA" "Font A");
 }


### PR DESCRIPTION
This adds support to local references when using `font-face`, for example:

``` sass
@include font-face(MyHelvetica, MgOpenModernaBold, bold, 
                   $file-formats: ttf, 
                   $local-references: 'Helvetica Neue Bold' 'HelveticaNeue-Bold');
```

outputs:

``` css
@font-face {
  font-family: MyHelvetica;
  font-style: normal;
  font-weight: bold;
  src: local("Helvetica Neue Bold"), 
       local("HelveticaNeue-Bold"), 
       url("MgOpenModernaBold.ttf") format("truetype"); }
```

After this gets accepted I'll send another pull-request to document it on `gh-pages`.
