### PR TITLE
Make Bourbon a proper npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,8 @@
 .gitignore
 .hound.yml
 .sass-cache
+.scss-lint.yml
+.travis.yml
 _site
 bin/
 bourbon.gemspec

--- a/index.js
+++ b/index.js
@@ -1,0 +1,7 @@
+var path = require('path');
+
+module.exports = {
+  includePaths: [
+    path.join(__dirname, 'app/assets/stylesheets')
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "name": "thoughtbot",
     "url": "http://thoughtbot.com"
   },
-  "main": "app/assets/stylesheets/_bourbon.scss",
+  "main": "index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/thoughtbot/bourbon.git"


### PR DESCRIPTION
I have no idea what I’m doing…but this does work locally for me. I think this makes Bourbon a proper npm package that can easily be used with things like build tools.

Example `Gulpfile.js`:

```js
var gulp = require('gulp');
var sass = require('gulp-sass');

gulp.task('stylesheets', function () {
  gulp.src('./stylesheets/**/*.scss')
    .pipe(sass({
      includePaths: require('bourbon').includePaths
    }))
    .pipe(gulp.dest('./stylesheets'));
});

gulp.task('default', function () {
  gulp.watch('./stylesheets/**/*.scss', ['stylesheets']);
});
```

@creuter @joshuaogle Do either of you have any context on this stuff? I’d love a review.