### PR TITLE
Fix `bourbon update` when Bourbon installed in a custom path

### DIFF
--- a/lib/bourbon/generator.rb
+++ b/lib/bourbon/generator.rb
@@ -54,7 +54,7 @@ module Bourbon
     end
 
     def remove_bourbon_directory
-      FileUtils.rm_rf("bourbon")
+      FileUtils.rm_rf(install_path)
     end
 
     def make_install_directory


### PR DESCRIPTION
The `update` method removes Bourbon's directory and reinstall it.
The directory removed was wrong in case of a custom installation path.
This commit fix it by making it removing the custom path directory.
