### PR TITLE
Remove unnecessary vendor prefixes from transition

### DIFF
--- a/app/assets/stylesheets/css3/_transition.scss
+++ b/app/assets/stylesheets/css3/_transition.scss
@@ -7,7 +7,6 @@
   // Fix for vendor-prefix transform property
   $needs-prefixes: false;
   $webkit: ();
-  $moz: ();
   $spec: ();
 
   // Create lists for vendor-prefixed transform
@@ -15,7 +14,6 @@
     @if nth($list, 1) == "transform" {
       $needs-prefixes: true;
       $list1: -webkit-transform;
-      $list2: -moz-transform;
       $list3: ();
 
       @each $var in $list {
@@ -28,44 +26,39 @@
       }
 
       $webkit: append($webkit, $list1);
-      $moz:    append($moz,    $list2);
       $spec:   append($spec,   $list3);
     } @else {
       $webkit: append($webkit, $list, comma);
-      $moz:    append($moz,    $list, comma);
       $spec:   append($spec,   $list, comma);
     }
   }
 
   @if $needs-prefixes {
     -webkit-transition: $webkit;
-       -moz-transition: $moz;
             transition: $spec;
   } @else {
     @if length($properties) >= 1 {
-      @include prefixer(transition, $properties, webkit moz spec);
+      @include prefixer(transition, $properties, spec);
     } @else {
       $properties: all 0.15s ease-out 0s;
-      @include prefixer(transition, $properties, webkit moz spec);
+      @include prefixer(transition, $properties, spec);
     }
   }
 }
 
 @mixin transition-property($properties...) {
-  -webkit-transition-property: transition-property-names($properties, "webkit");
-     -moz-transition-property: transition-property-names($properties, "moz");
-          transition-property: transition-property-names($properties, false);
+  transition-property: transition-property-names($properties, false);
 }
 
 @mixin transition-duration($times...) {
-  @include prefixer(transition-duration, $times, webkit moz spec);
+  @include prefixer(transition-duration, $times, spec);
 }
 
 @mixin transition-timing-function($motions...) {
   // ease | linear | ease-in | ease-out | ease-in-out | cubic-bezier()
-  @include prefixer(transition-timing-function, $motions, webkit moz spec);
+  @include prefixer(transition-timing-function, $motions, spec);
 }
 
 @mixin transition-delay($times...) {
-  @include prefixer(transition-delay, $times, webkit moz spec);
+  @include prefixer(transition-delay, $times, spec);
 }


### PR DESCRIPTION
The transition property should only use a polyfill if transitioning the `transform` property.

Transitions by themselves no longer require vendor prefixes ([source 1](https://developer.mozilla.org/en-US/docs/Web/CSS/transition)[source 2](http://caniuse.com/#feat=css-transitions)).

Transitions only require a polyfill if supporting transforms, which only need the `-webkit` prefix. ([source](http://caniuse.com/#feat=transforms2d))