### PR TITLE
Remove left and repeat for radial-gradient in examples

### DIFF
--- a/_includes/mixins/background.html
+++ b/_includes/mixins/background.html
@@ -8,7 +8,7 @@
 
 {% highlight scss %}
 @include background(linear-gradient(red, green) left repeat);
-@include background(linear-gradient(red, green) left repeat, radial-gradient(red, orange) left repeat);
+@include background(linear-gradient(red, green) left repeat, radial-gradient(red, orange));
 @include background(url("/images/a.png"), linear-gradient(red, green), center no-repeat orange scroll);
 {% endhighlight %}
 </article>


### PR DESCRIPTION
After testing `@include background` on CodePen, I noticed a small mistake in your `radial-gradient` example. Therefore I removed the `left repeat` that shouldn't be at the end of the parameters list.