### PR TITLE
Add contrasting-color function

### DIFF
--- a/core/_bourbon.scss
+++ b/core/_bourbon.scss
@@ -32,6 +32,7 @@
 @import "bourbon/addons/border-width";
 @import "bourbon/addons/buttons";
 @import "bourbon/addons/clearfix";
+@import "bourbon/addons/contrast-switch";
 @import "bourbon/addons/ellipsis";
 @import "bourbon/addons/font-stacks";
 @import "bourbon/addons/hide-text";

--- a/core/bourbon/addons/_contrast-switch.scss
+++ b/core/bourbon/addons/_contrast-switch.scss
@@ -1,0 +1,42 @@
+@charset "UTF-8";
+
+/// Switches between two colors based on the lightness of a another color. Great
+/// for building button styles.
+///
+/// @param {color} $base-color
+/// The `color` to evaluate lightness against
+///
+/// @param {color} $light-color [#000]
+/// The `color` to be output when `base-color` is light
+///
+/// @param {color} $dark-color [#fff]
+/// The `color` to be output when `base-color` is dark
+///
+/// @example scss
+/// .first-element {
+///   color: contrast-switch(#bae6e6);
+/// }
+///
+/// .second-element {
+///   $button-color: #2d72d9;
+///   background-color: $button-color;
+///   color: contrast-switch($button-color, #222, #eee);
+/// }
+///
+/// @example css
+/// .first-element {
+///   color: #000;
+/// }
+///
+/// .second-element {
+///   background-color: #2d72d9;
+///   color: #eee;
+/// }
+///
+/// @require {function} is-light
+///
+/// @since 5.0.0
+
+@function contrast-switch($base-color, $light-color: #000, $dark-color: #fff) {
+  @return if(is-light($base-color), $light-color, $dark-color);
+}

--- a/spec/bourbon/addons/contrast_switch_spec.rb
+++ b/spec/bourbon/addons/contrast_switch_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+describe "contrast-switch" do
+  before(:all) do
+    ParserSupport.parse_file("addons/contrast-switch")
+  end
+
+  context "called with a light base color" do
+    it "outputs the dark color" do
+      rule = "color: #000;"
+
+      expect(".contrast-switch-light-base").to have_ruleset(rule)
+    end
+  end
+
+  context "called with a dark base color" do
+    it "outputs the light color" do
+      rule = "color: #eee;"
+
+      expect(".contrast-switch-dark-base").to have_ruleset(rule)
+    end
+  end
+end

--- a/spec/fixtures/addons/contrast-switch.scss
+++ b/spec/fixtures/addons/contrast-switch.scss
@@ -1,0 +1,9 @@
+@import "setup";
+
+.contrast-switch-light-base {
+  color: contrast-switch(#bae6e6);
+}
+
+.contrast-switch-dark-base {
+  color: contrast-switch(#2d72d9, #222, #eee);
+}


### PR DESCRIPTION
Bourbon has had an [`is-light`](https://github.com/thoughtbot/bourbon/blob/master/app/assets/stylesheets/functions/_is-light.scss) function for awhile now (we used to use it in our now-deprecated `button` mixin). This new `contrasting-color` function builds on `is-light` and allows you to pass it arguments to easily output a light or dark color of your choosing based on the lightness of another color.

So for example, our [default button styles](https://github.com/thoughtbot/bitters/blob/master/app/assets/stylesheets/_buttons.scss) in Bitters could become a bit smarter/more flexible (for brevity, I’m only showing the affected styles below): 

```scss
#{$all-buttons} {
  background-color: $action-color;
  color: contrasting-color($action-color, #000, #fff);
}
```

cc: @whmii

- [x] Needs documentation
- [x] Needs tests