### PR TITLE
Added -moz- prefix to calc

### DIFF
--- a/app/assets/stylesheets/css3/_calc.scss
+++ b/app/assets/stylesheets/css3/_calc.scss
@@ -1,4 +1,5 @@
 @mixin calc($property, $value) {
+  #{$property}: -moz-calc(#{$value});
   #{$property}: -webkit-calc(#{$value});
   #{$property}: calc(#{$value});
 }


### PR DESCRIPTION
Based on http://caniuse.com/#feat=calc , Firefox 4 to 15 needs -moz- prefix for calc.