### PR TITLE
Add pad alias to padding mixin

### DIFF
--- a/core/_bourbon.scss
+++ b/core/_bourbon.scss
@@ -37,6 +37,7 @@
 @import "bourbon/addons/hide-text";
 @import "bourbon/addons/margin";
 @import "bourbon/addons/padding";
+@import "bourbon/addons/pad";
 @import "bourbon/addons/position";
 @import "bourbon/addons/prefixer";
 @import "bourbon/addons/size";

--- a/core/bourbon/addons/_pad.scss
+++ b/core/bourbon/addons/_pad.scss
@@ -1,0 +1,27 @@
+@charset "UTF-8";
+
+/// Provides a quick method for targeting `padding` on specific sides of a box. Use a `null` value to “skip” a side.
+///
+/// @param {arglist} $values
+/// List of padding values, defined as CSS shorthand
+///
+/// @example scss
+/// .element {
+///   @include pad(50vh null 1rem);
+/// }
+///
+/// @example css
+/// .element {
+///   padding-bottom: 1rem;
+///   padding-top: 50vh;
+/// }
+///
+/// @require {mixin} padding
+///
+/// @output `padding`
+///
+/// @alias {mixin} padding
+
+@mixin pad($values...) {
+  @include padding($values...);
+}


### PR DESCRIPTION
We aim for Bourbon’s features to be human-readable and _clarity_ tends to take precedence over brevity. So a lot of our mixin and function names are not shortened or abbreviated. If you open the stylesheet, someone new to Bourbon should be able to quickly understand what things are doing.

There’s a couple places where we might be able to get away with both clarity and brevity, and one such place is the `padding` mixin…

So I’m tossing up the idea of aliasing our current `padding` mixin:

```scss
@include padding(1rem null);
```

…with a mixin defined as `pad`:

```scss
@include pad(1rem null);
```

1. Thoughts?
- Is this worthwhile?
- Are we opening a can of worms by doing this for one mixin, and not for all?