### PR TITLE
Change 'application.css.scss' to just 'application.scss'

### DIFF
--- a/index.html
+++ b/index.html
@@ -165,17 +165,17 @@ gem 'bourbon'
 $ bundle install
 {% endhighlight %}
 
-        <p>Restart your server. Then rename <code>application.css</code> to <code>application.css.scss</code>:</p>
+        <p>Restart your server. Then rename <code>application.css</code> to <code>application.scss</code>:</p>
 {% highlight powershell %}
-mv app/assets/stylesheets/application.css app/assets/stylesheets/application.css.scss
+mv app/assets/stylesheets/application.css app/assets/stylesheets/application.scss
 {% endhighlight %}
 
-        <p>Delete the sprocket directive in application.css.scss:</p>
+        <p>Delete the sprocket directive in application.scss:</p>
 {% highlight powershell %}
 *= require_tree .
 {% endhighlight %}
 
-        <p>Import Bourbon at the beginning of application.css.scss. All additional stylesheets must be imported below Bourbon:</p>
+        <p>Import Bourbon at the beginning of application.scss. All additional stylesheets must be imported below Bourbon:</p>
 {% highlight scss %}
 @import "bourbon";
 @import "home";


### PR DESCRIPTION
I noticed [bourbon.io](http://bourbon.io) still still referenced renaming `application.css` to `application.css.scss`. 

It's my understanding that this is unnecessary, and just `application.scss` is sufficient. 

Related commit, for the same update in the README: https://github.com/thoughtbot/bourbon/commit/82f948437812385636fd6fe398da7455c1a13392