### PR TITLE
Pass Display variable in Ellipsis mixin

### DIFF
--- a/app/assets/stylesheets/addons/_ellipsis.scss
+++ b/app/assets/stylesheets/addons/_ellipsis.scss
@@ -20,8 +20,8 @@
 ///     word-wrap: normal;
 ///   }
 
-@mixin ellipsis($width: 100%) {
-  display: inline-block;
+@mixin ellipsis($width: 100%, $display: inline-block) {
+  display: $display;
   max-width: $width;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
Ran into a situation where I didn't want the element to be `display: inline-block` and figured others might have as well.