### PR TITLE
Remove unused 2011 flex-direction variable

### DIFF
--- a/app/assets/stylesheets/css3/_flex-box.scss
+++ b/app/assets/stylesheets/css3/_flex-box.scss
@@ -113,7 +113,6 @@
 
   // Alt values.
   $value-2009: $value;
-  $value-2011: $value;
   $direction: normal;
 
   @if $value == row {


### PR DESCRIPTION
I noticed that the variable `value-2011` was unused while studying the source of the `flex-direction` mixin