### PR TITLE
Conifigure CircleCI to not test the gh-pages branch

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,4 @@
+general:
+  branches:
+    ignore:
+      - gh-pages


### PR DESCRIPTION
…because it’s our website that runs on Jekyll in that branch and we have no tests there.

More information can be found here: https://circleci.com/docs/configuration