### PR TITLE
Add system font stack

### DIFF
--- a/core/bourbon/addons/_font-stacks.scss
+++ b/core/bourbon/addons/_font-stacks.scss
@@ -6,14 +6,18 @@
 /// @link goo.gl/Cxb26i
 ////
 
-$helvetica: "Helvetica Neue", "Helvetica", "Arial", sans-serif;
-$lucida-grande: "Lucida Grande", "Lucida Sans Unicode", "Geneva", "Verdana", sans-serif;
-$verdana: "Verdana", "Geneva", sans-serif;
+$font-stack-helvetica: "Helvetica Neue", "Helvetica", "Arial", sans-serif;
+$font-stack-lucida-grande: "Lucida Grande", "Lucida Sans Unicode", "Geneva",
+  "Verdana", sans-serif;
+$font-stack-verdana: "Verdana", "Geneva", sans-serif;
 
-$garamond: "Garamond", "Baskerville", "Baskerville Old Face", "Hoefler Text", "Times New Roman", serif;
-$georgia: "Georgia", "Times", "Times New Roman", serif;
-$hoefler-text: "Hoefler Text", "Baskerville Old Face", "Garamond", "Times New Roman", serif;
+$font-stack-garamond: "Garamond", "Baskerville", "Baskerville Old Face",
+  "Hoefler Text", "Times New Roman", serif;
+$font-stack-georgia: "Georgia", "Times", "Times New Roman", serif;
+$font-stack-hoefler-text: "Hoefler Text", "Baskerville Old Face", "Garamond",
+  "Times New Roman", serif;
 
-$consolas: "Consolas", "monaco", monospace;
-$courier-new: "Courier New", "Courier", "Lucida Sans Typewriter", "Lucida Typewriter", monospace;
-$monaco: "monaco", "Consolas", "Lucida Console", monospace;
+$font-stack-consolas: "Consolas", "monaco", monospace;
+$font-stack-courier-new: "Courier New", "Courier", "Lucida Sans Typewriter",
+  "Lucida Typewriter", monospace;
+$font-stack-monaco: "monaco", "Consolas", "Lucida Console", monospace;

--- a/core/bourbon/addons/_font-stacks.scss
+++ b/core/bourbon/addons/_font-stacks.scss
@@ -21,3 +21,7 @@ $font-stack-consolas: "Consolas", "monaco", monospace;
 $font-stack-courier-new: "Courier New", "Courier", "Lucida Sans Typewriter",
   "Lucida Typewriter", monospace;
 $font-stack-monaco: "monaco", "Consolas", "Lucida Console", monospace;
+
+$font-stack-system: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto",
+  "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
+  sans-serif;

--- a/spec/bourbon/addons/font_stacks_spec.rb
+++ b/spec/bourbon/addons/font_stacks_spec.rb
@@ -21,6 +21,10 @@ describe "font-stacks" do
                     '"Lucida Typewriter", monospace'
       monaco = '"monaco", "Consolas", "Lucida Console", monospace'
 
+      system = '-apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", ' +
+               '"Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", ' +
+               '"Helvetica Neue", sans-serif'
+
       expect(".helvetica").to have_value(helvetica)
       expect(".lucida-grande").to have_value(lucida_grande)
       expect(".verdana").to have_value(verdana)
@@ -30,6 +34,7 @@ describe "font-stacks" do
       expect(".consolas").to have_value(consolas)
       expect(".courier-new").to have_value(courier_new)
       expect(".monaco").to have_value(monaco)
+      expect(".system").to have_value(system)
     end
   end
 end

--- a/spec/fixtures/addons/font-stacks.scss
+++ b/spec/fixtures/addons/font-stacks.scss
@@ -35,3 +35,7 @@
 .monaco {
   content: $font-stack-monaco;
 }
+
+.system {
+  content: $font-stack-system;
+}

--- a/spec/fixtures/addons/font-stacks.scss
+++ b/spec/fixtures/addons/font-stacks.scss
@@ -1,37 +1,37 @@
 @import "setup";
 
 .helvetica {
-  content: $helvetica;
+  content: $font-stack-helvetica;
 }
 
 .lucida-grande {
-  content: $lucida-grande;
+  content: $font-stack-lucida-grande;
 }
 
 .verdana {
-  content: $verdana;
+  content: $font-stack-verdana;
 }
 
 .garamond {
-  content: $garamond;
+  content: $font-stack-garamond;
 }
 
 .georgia {
-  content: $georgia;
+  content: $font-stack-georgia;
 }
 
 .hoefler-text {
-  content: $hoefler-text;
+  content: $font-stack-hoefler-text;
 }
 
 .consolas {
-  content: $consolas;
+  content: $font-stack-consolas;
 }
 
 .courier-new {
-  content: $courier-new;
+  content: $font-stack-courier-new;
 }
 
 .monaco {
-  content: $monaco;
+  content: $font-stack-monaco;
 }


### PR DESCRIPTION
I think there are some great use cases for using system fonts. This adds a robust system font stack as a variable.

It was tough to name this one. `$system` would be a terrible name. So I prefixed this with `font-stack-`; I think if we like this approach, then all of these font stack variable should also be prefixed the same way.

More info: https://www.smashingmagazine.com/2015/11/using-system-ui-fonts-practical-guide/