### PR TITLE
Use failure_message instead of failure_message_for_should

### DIFF
--- a/spec/support/matchers/have_value.rb
+++ b/spec/support/matchers/have_value.rb
@@ -9,7 +9,7 @@ RSpec::Matchers.define :have_value do |expected|
     end
   end
 
-  failure_message_for_should do |variable_name|
+  failure_message do |variable_name|
     value_attribute = @value_attribute.to_s
     %{Expected variable #{variable_name} to have value "#{expected}".
       Had "#{value_attribute}".}


### PR DESCRIPTION
I execute `rake spec` command and get warning on Rspec.
I fix it.

Thank you.
