### PR TITLE
Indent SassDoc example annotations

### DIFF
--- a/core/bourbon/addons/_border-color.scss
+++ b/core/bourbon/addons/_border-color.scss
@@ -1,21 +1,22 @@
 @charset "UTF-8";
 
-/// Provides a quick method for targeting `border-color` on specific sides of a box. Use a `null` value to “skip” a side.
+/// Provides a quick method for targeting `border-color` on specific sides of a
+/// box. Use a `null` value to “skip” a side.
 ///
 /// @argument {arglist} $values
-/// List of colors, defined as CSS shorthand
+///   List of colors, defined as CSS shorthand
 ///
 /// @example scss
-/// .element {
-///   @include border-color(#a60b55 #76cd9c null #e8ae1a);
-/// }
+///   .element {
+///     @include border-color(#a60b55 #76cd9c null #e8ae1a);
+///   }
 ///
 /// @example css
-/// .element {
-///   border-left-color: #e8ae1a;
-///   border-right-color: #76cd9c;
-///   border-top-color: #a60b55;
-/// }
+///   .element {
+///     border-left-color: #e8ae1a;
+///     border-right-color: #76cd9c;
+///     border-top-color: #a60b55;
+///   }
 ///
 /// @require {mixin} directional-property
 ///

--- a/core/bourbon/addons/_border-radius.scss
+++ b/core/bourbon/addons/_border-radius.scss
@@ -1,30 +1,31 @@
 @charset "UTF-8";
 
-/// Provides a quick method for targeting `border-radius` on both corners on the side of a box.
+/// Provides a quick method for targeting `border-radius` on both corners on the
+/// side of a box.
 ///
 /// @argument {number} $radii
 ///
 /// @example scss
-/// .element-one {
-///   @include border-top-radius(5px);
-/// }
+///   .element-one {
+///     @include border-top-radius(5px);
+///   }
 ///
 /// @example css
-/// .element-one {
-///   border-top-left-radius: 5px;
-///   border-top-right-radius: 5px;
-/// }
+///   .element-one {
+///     border-top-left-radius: 5px;
+///     border-top-right-radius: 5px;
+///   }
 ///
 /// @example scss
-/// .element-two {
-///   @include border-left-radius(3px);
-/// }
+///   .element-two {
+///     @include border-left-radius(3px);
+///   }
 ///
 /// @example css
-/// .element-two {
-///   border-bottom-left-radius: 3px;
-///   border-top-left-radius: 3px;
-/// }
+///   .element-two {
+///     border-bottom-left-radius: 3px;
+///     border-top-left-radius: 3px;
+///   }
 ///
 /// @output `border-radius`
 

--- a/core/bourbon/addons/_border-style.scss
+++ b/core/bourbon/addons/_border-style.scss
@@ -1,20 +1,21 @@
 @charset "UTF-8";
 
-/// Provides a quick method for targeting `border-style` on specific sides of a box. Use a `null` value to “skip” a side.
+/// Provides a quick method for targeting `border-style` on specific sides of a
+/// box. Use a `null` value to “skip” a side.
 ///
 /// @argument {arglist} $values
-/// List of border styles, defined as CSS shorthand
+///   List of border styles, defined as CSS shorthand
 ///
 /// @example scss
-/// .element {
-///   @include border-style(dashed null solid);
-/// }
+///   .element {
+///     @include border-style(dashed null solid);
+///   }
 ///
 /// @example css
-/// .element {
-///   border-bottom-style: solid;
-///   border-top-style: dashed;
-/// }
+///   .element {
+///     border-bottom-style: solid;
+///     border-top-style: dashed;
+///   }
 ///
 /// @require {mixin} directional-property
 ///

--- a/core/bourbon/addons/_border-width.scss
+++ b/core/bourbon/addons/_border-width.scss
@@ -1,20 +1,21 @@
 @charset "UTF-8";
 
-/// Provides a quick method for targeting `border-width` on specific sides of a box. Use a `null` value to “skip” a side.
+/// Provides a quick method for targeting `border-width` on specific sides of a
+/// box. Use a `null` value to “skip” a side.
 ///
 /// @argument {arglist} $values
-/// List of border widths, defined as CSS shorthand
+///   List of border widths, defined as CSS shorthand
 ///
 /// @example scss
-/// .element {
-///   @include border-width(1em null 20px);
-/// }
+///   .element {
+///     @include border-width(1em null 20px);
+///   }
 ///
 /// @example css
-/// .element {
-///   border-bottom-width: 20px;
-///   border-top-width: 1em;
-/// }
+///   .element {
+///     border-bottom-width: 20px;
+///     border-top-width: 1em;
+///   }
 ///
 /// @require {mixin} directional-property
 ///

--- a/core/bourbon/addons/_buttons.scss
+++ b/core/bourbon/addons/_buttons.scss
@@ -2,47 +2,48 @@
 
 // scss-lint:disable StringQuotes
 
-/// Generates variables for all buttons. Please note that you must use interpolation on the variable: `#{$all-buttons}`.
+/// Generates variables for all buttons. Please note that you must use
+/// interpolation on the variable: `#{$all-buttons}`.
 ///
 /// @example scss
-/// #{$all-buttons} {
-///   background-color: #f00;
-/// }
+///   #{$all-buttons} {
+///     background-color: #f00;
+///   }
 ///
-/// #{$all-buttons-focus},
-/// #{$all-buttons-hover} {
-///   background-color: #0f0;
-/// }
+///   #{$all-buttons-focus},
+///   #{$all-buttons-hover} {
+///     background-color: #0f0;
+///   }
 ///
-/// #{$all-buttons-active} {
-///   background-color: #00f;
-/// }
+///   #{$all-buttons-active} {
+///     background-color: #00f;
+///   }
 ///
 /// @example css
-/// button,
-/// [type="button"],
-/// [type="reset"],
-/// [type="submit"] {
-///   background-color: #f00;
-/// }
+///   button,
+///   [type="button"],
+///   [type="reset"],
+///   [type="submit"] {
+///     background-color: #f00;
+///   }
 ///
-/// button:focus,
-/// [type="button"]:focus,
-/// [type="reset"]:focus,
-/// [type="submit"]:focus,
-/// button:hover,
-/// [type="button"]:hover,
-/// [type="reset"]:hover,
-/// [type="submit"]:hover {
-///   background-color: #0f0;
-/// }
+///   button:focus,
+///   [type="button"]:focus,
+///   [type="reset"]:focus,
+///   [type="submit"]:focus,
+///   button:hover,
+///   [type="button"]:hover,
+///   [type="reset"]:hover,
+///   [type="submit"]:hover {
+///     background-color: #0f0;
+///   }
 ///
-/// button:active,
-/// [type="button"]:active,
-/// [type="reset"]:active,
-/// [type="submit"]:active {
-///   background-color: #00f;
-/// }
+///   button:active,
+///   [type="button"]:active,
+///   [type="reset"]:active,
+///   [type="submit"]:active {
+///     background-color: #00f;
+///   }
 ///
 /// @require {function} assign-inputs
 ///

--- a/core/bourbon/addons/_clearfix.scss
+++ b/core/bourbon/addons/_clearfix.scss
@@ -5,16 +5,16 @@
 /// @link http://goo.gl/0VEum5
 ///
 /// @example scss
-/// .element {
-///   @include clearfix;
-/// }
+///   .element {
+///     @include clearfix;
+///   }
 ///
 /// @example css
-/// .element::after {
-///   clear: both;
-///   content: "";
-///   display: table;
-/// }
+///   .element::after {
+///     clear: both;
+///     content: "";
+///     display: table;
+///   }
 
 @mixin clearfix {
   &::after {

--- a/core/bourbon/addons/_contrast-switch.scss
+++ b/core/bourbon/addons/_contrast-switch.scss
@@ -4,34 +4,34 @@
 /// for building button styles.
 ///
 /// @argument {color} $base-color
-/// The `color` to evaluate lightness against
+///   The `color` to evaluate lightness against
 ///
 /// @argument {color} $light-color [#000]
-/// The `color` to be output when `base-color` is light
+///   The `color` to be output when `base-color` is light
 ///
 /// @argument {color} $dark-color [#fff]
-/// The `color` to be output when `base-color` is dark
+///   The `color` to be output when `base-color` is dark
 ///
 /// @example scss
-/// .first-element {
-///   color: contrast-switch(#bae6e6);
-/// }
+///   .first-element {
+///     color: contrast-switch(#bae6e6);
+///   }
 ///
-/// .second-element {
-///   $button-color: #2d72d9;
-///   background-color: $button-color;
-///   color: contrast-switch($button-color, #222, #eee);
-/// }
+///   .second-element {
+///     $button-color: #2d72d9;
+///     background-color: $button-color;
+///     color: contrast-switch($button-color, #222, #eee);
+///   }
 ///
 /// @example css
-/// .first-element {
-///   color: #000;
-/// }
+///   .first-element {
+///     color: #000;
+///   }
 ///
-/// .second-element {
-///   background-color: #2d72d9;
-///   color: #eee;
-/// }
+///   .second-element {
+///     background-color: #2d72d9;
+///     color: #eee;
+///   }
 ///
 /// @require {function} is-light
 ///

--- a/core/bourbon/addons/_ellipsis.scss
+++ b/core/bourbon/addons/_ellipsis.scss
@@ -3,25 +3,25 @@
 /// Truncates text and adds an ellipsis to represent overflow.
 ///
 /// @argument {number} $width [100%]
-/// The `max-width` for the string to respect before being truncated
+///   The `max-width` for the string to respect before being truncated
 ///
 /// @argument {string} $display [inline-block]
-/// Sets the display-value of the element
+///   Sets the display-value of the element
 ///
 /// @example scss
-/// .element {
-///   @include ellipsis;
-/// }
+///   .element {
+///     @include ellipsis;
+///   }
 ///
 /// @example css
-/// .element {
-///   display: inline-block;
-///   max-width: 100%;
-///   overflow: hidden;
-///   text-overflow: ellipsis;
-///   white-space: nowrap;
-///   word-wrap: normal;
-/// }
+///   .element {
+///     display: inline-block;
+///     max-width: 100%;
+///     overflow: hidden;
+///     text-overflow: ellipsis;
+///     white-space: nowrap;
+///     word-wrap: normal;
+///   }
 
 @mixin ellipsis($width: 100%, $display: inline-block) {
   display: $display;

--- a/core/bourbon/addons/_hide-text.scss
+++ b/core/bourbon/addons/_hide-text.scss
@@ -1,20 +1,21 @@
 @charset "UTF-8";
 
-/// Hides the text in an element, commonly used to show an image instead. Some elements will need block-level styles applied.
+/// Hides the text in an element, commonly used to show an image instead. Some
+/// elements will need block-level styles applied.
 ///
 /// @link http://goo.gl/EvLRIu
 ///
 /// @example scss
-/// .element {
-///   @include hide-text;
-/// }
+///   .element {
+///     @include hide-text;
+///   }
 ///
 /// @example css
-/// .element {
-///   overflow: hidden;
-///   text-indent: 101%;
-///   white-space: nowrap;
-/// }
+///   .element {
+///     overflow: hidden;
+///     text-indent: 101%;
+///     white-space: nowrap;
+///   }
 
 @mixin hide-text {
   overflow: hidden;

--- a/core/bourbon/addons/_margin.scss
+++ b/core/bourbon/addons/_margin.scss
@@ -1,21 +1,22 @@
 @charset "UTF-8";
 
-/// Provides a quick method for targeting `margin` on specific sides of a box. Use a `null` value to “skip” a side.
+/// Provides a quick method for targeting `margin` on specific sides of a
+/// box. Use a `null` value to “skip” a side.
 ///
 /// @argument {arglist} $values
-/// List of margin values, defined as CSS shorthand
+///   List of margin values, defined as CSS shorthand
 ///
 /// @example scss
-/// .element {
-///   @include margin(null 10px 3em 20vh);
-/// }
+///   .element {
+///     @include margin(null 10px 3em 20vh);
+///   }
 ///
 /// @example css
-/// .element {
-///   margin-bottom: 3em;
-///   margin-left: 20vh;
-///   margin-right: 10px;
-/// }
+///   .element {
+///     margin-bottom: 3em;
+///     margin-left: 20vh;
+///     margin-right: 10px;
+///   }
 ///
 /// @require {mixin} directional-property
 ///

--- a/core/bourbon/addons/_padding.scss
+++ b/core/bourbon/addons/_padding.scss
@@ -1,21 +1,22 @@
 @charset "UTF-8";
 
-/// Provides a quick method for targeting `padding` on specific sides of a box. Use a `null` value to “skip” a side.
+/// Provides a quick method for targeting `padding` on specific sides of a
+/// box. Use a `null` value to “skip” a side.
 ///
 /// @argument {arglist} $values
-/// List of padding values, defined as CSS shorthand
+///   List of padding values, defined as CSS shorthand
 ///
 /// @example scss
-/// .element {
-///   @include padding(12vh null 10px 5%);
-/// }
+///   .element {
+///     @include padding(12vh null 10px 5%);
+///   }
 ///
 /// @example css
-/// .element {
-///   padding-bottom: 10px;
-///   padding-left: 5%;
-///   padding-top: 12vh;
-/// }
+///   .element {
+///     padding-bottom: 10px;
+///     padding-left: 5%;
+///     padding-top: 12vh;
+///   }
 ///
 /// @require {mixin} directional-property
 ///

--- a/core/bourbon/addons/_position.scss
+++ b/core/bourbon/addons/_position.scss
@@ -1,24 +1,25 @@
 @charset "UTF-8";
 
-/// Provides a quick method for setting an element’s position. Use a `null` value to “skip” a side.
+/// Provides a quick method for setting an element’s position. Use a `null`
+/// value to “skip” a side.
 ///
 /// @argument {string} $position [relative]
-/// A CSS position value
+///   A CSS position value
 ///
 /// @argument {arglist} $coordinates [null]
-/// List of lengths, defined as CSS shorthand
+///   List of lengths, defined as CSS shorthand
 ///
 /// @example scss
-/// .element {
-///   @include position(absolute, 0 null null 10em);
-/// }
+///   .element {
+///     @include position(absolute, 0 null null 10em);
+///   }
 ///
 /// @example css
-/// .element {
-///   left: 10em;
-///   position: absolute;
-///   top: 0;
-/// }
+///   .element {
+///     left: 10em;
+///     position: absolute;
+///     top: 0;
+///   }
 ///
 /// @require {function} is-length
 ///

--- a/core/bourbon/addons/_prefixer.scss
+++ b/core/bourbon/addons/_prefixer.scss
@@ -3,25 +3,25 @@
 /// Generates vendor prefixes.
 ///
 /// @argument {string} $property
-/// Property to prefix
+///   Property to prefix
 ///
 /// @argument {string} $value
-/// Value to use
+///   Value to use
 ///
 /// @argument {list} $prefixes
-/// Vendor prefixes to output
+///   Vendor prefixes to output
 ///
 /// @example scss
-/// .element {
-///   @include prefixer(appearance, none, webkit moz);
-/// }
+///   .element {
+///     @include prefixer(appearance, none, webkit moz);
+///   }
 ///
 /// @example css
-/// .element {
-///   -webkit-appearance: none;
-///   -moz-appearance: none;
-///   appearance: none;
-/// }
+///   .element {
+///     -webkit-appearance: none;
+///     -moz-appearance: none;
+///     appearance: none;
+///   }
 ///
 /// @author Hugo Giraudel
 

--- a/core/bourbon/addons/_size.scss
+++ b/core/bourbon/addons/_size.scss
@@ -7,24 +7,24 @@
 /// @argument {number} $height [$width]
 ///
 /// @example scss
-/// .first-element {
-///   @include size(2em);
-/// }
+///   .first-element {
+///     @include size(2em);
+///   }
 ///
-/// .second-element {
-///   @include size(auto, 10em);
-/// }
+///   .second-element {
+///     @include size(auto, 10em);
+///   }
 ///
 /// @example css
-/// .first-element {
-///   width: 2em;
-///   height: 2em;
-/// }
+///   .first-element {
+///     width: 2em;
+///     height: 2em;
+///   }
 ///
-/// .second-element {
-///   width: auto;
-///   height: 10em;
-/// }
+///   .second-element {
+///     width: auto;
+///     height: 10em;
+///   }
 ///
 /// @require {function} is-size
 

--- a/core/bourbon/addons/_text-inputs.scss
+++ b/core/bourbon/addons/_text-inputs.scss
@@ -2,99 +2,100 @@
 
 // scss-lint:disable StringQuotes
 
-/// Generates variables for all text-based inputs. Please note that you must use interpolation on the variable: `#{$all-text-inputs}`.
+/// Generates variables for all text-based inputs. Please note that you must use
+/// interpolation on the variable: `#{$all-text-inputs}`.
 ///
 /// @example scss
-/// #{$all-text-inputs} {
-///   border: 1px solid #f00;
-/// }
+///   #{$all-text-inputs} {
+///     border: 1px solid #f00;
+///   }
 ///
 /// @example css
-/// [type="color"],
-/// [type="date"],
-/// [type="datetime"],
-/// [type="datetime-local"],
-/// [type="email"],
-/// [type="month"],
-/// [type="number"],
-/// [type="password"],
-/// [type="search"],
-/// [type="tel"],
-/// [type="text"],
-/// [type="time"],
-/// [type="url"],
-/// [type="week"],
-/// input:not([type]),
-/// textarea {
-///   border: 1px solid #f00;
-/// }
+///   [type="color"],
+///   [type="date"],
+///   [type="datetime"],
+///   [type="datetime-local"],
+///   [type="email"],
+///   [type="month"],
+///   [type="number"],
+///   [type="password"],
+///   [type="search"],
+///   [type="tel"],
+///   [type="text"],
+///   [type="time"],
+///   [type="url"],
+///   [type="week"],
+///   input:not([type]),
+///   textarea {
+///     border: 1px solid #f00;
+///   }
 ///
 /// @example scss
-/// #{$all-text-inputs-focus},
-/// #{$all-text-inputs-hover} {
-///   border: 1px solid #0f0;
-/// }
+///   #{$all-text-inputs-focus},
+///   #{$all-text-inputs-hover} {
+///     border: 1px solid #0f0;
+///   }
 ///
 /// @example css
-/// [type="color"]:focus,
-/// [type="date"]:focus,
-/// [type="datetime"]:focus,
-/// [type="datetime-local"]:focus,
-/// [type="email"]:focus,
-/// [type="month"]:focus,
-/// [type="number"]:focus,
-/// [type="password"]:focus,
-/// [type="search"]:focus,
-/// [type="tel"]:focus,
-/// [type="text"]:focus,
-/// [type="time"]:focus,
-/// [type="url"]:focus,
-/// [type="week"]:focus,
-/// input:not([type]):focus,
-/// textarea:focus,
-/// [type="color"]:hover,
-/// [type="date"]:hover,
-/// [type="datetime"]:hover,
-/// [type="datetime-local"]:hover,
-/// [type="email"]:hover,
-/// [type="month"]:hover,
-/// [type="number"]:hover,
-/// [type="password"]:hover,
-/// [type="search"]:hover,
-/// [type="tel"]:hover,
-/// [type="text"]:hover,
-/// [type="time"]:hover,
-/// [type="url"]:hover,
-/// [type="week"]:hover,
-/// input:not([type]):hover,
-/// textarea:hover {
-///   border: 1px solid #0f0;
-/// }
+///   [type="color"]:focus,
+///   [type="date"]:focus,
+///   [type="datetime"]:focus,
+///   [type="datetime-local"]:focus,
+///   [type="email"]:focus,
+///   [type="month"]:focus,
+///   [type="number"]:focus,
+///   [type="password"]:focus,
+///   [type="search"]:focus,
+///   [type="tel"]:focus,
+///   [type="text"]:focus,
+///   [type="time"]:focus,
+///   [type="url"]:focus,
+///   [type="week"]:focus,
+///   input:not([type]):focus,
+///   textarea:focus,
+///   [type="color"]:hover,
+///   [type="date"]:hover,
+///   [type="datetime"]:hover,
+///   [type="datetime-local"]:hover,
+///   [type="email"]:hover,
+///   [type="month"]:hover,
+///   [type="number"]:hover,
+///   [type="password"]:hover,
+///   [type="search"]:hover,
+///   [type="tel"]:hover,
+///   [type="text"]:hover,
+///   [type="time"]:hover,
+///   [type="url"]:hover,
+///   [type="week"]:hover,
+///   input:not([type]):hover,
+///   textarea:hover {
+///     border: 1px solid #0f0;
+///   }
 ///
 /// @example scss
-/// #{$all-text-inputs-active} {
-///   border: 1px solid #00f;
-/// }
+///   #{$all-text-inputs-active} {
+///     border: 1px solid #00f;
+///   }
 ///
 /// @example css
-/// [type="color"]:active,
-/// [type="date"]:active,
-/// [type="datetime"]:active,
-/// [type="datetime-local"]:active,
-/// [type="email"]:active,
-/// [type="month"]:active,
-/// [type="number"]:active,
-/// [type="password"]:active,
-/// [type="search"]:active,
-/// [type="tel"]:active,
-/// [type="text"]:active,
-/// [type="time"]:active,
-/// [type="url"]:active,
-/// [type="week"]:active,
-/// input:not([type]):active,
-/// textarea:active {
-///   border: 1px solid #00f;
-/// }
+///   [type="color"]:active,
+///   [type="date"]:active,
+///   [type="datetime"]:active,
+///   [type="datetime-local"]:active,
+///   [type="email"]:active,
+///   [type="month"]:active,
+///   [type="number"]:active,
+///   [type="password"]:active,
+///   [type="search"]:active,
+///   [type="tel"]:active,
+///   [type="text"]:active,
+///   [type="time"]:active,
+///   [type="url"]:active,
+///   [type="week"]:active,
+///   input:not([type]):active,
+///   textarea:active {
+///     border: 1px solid #00f;
+///   }
 ///
 /// @require {function} assign-inputs
 ///

--- a/core/bourbon/addons/_word-wrap.scss
+++ b/core/bourbon/addons/_word-wrap.scss
@@ -3,19 +3,19 @@
 /// Provides an easy way to change the `word-wrap` property.
 ///
 /// @argument {string} $wrap [break-word]
-/// Value for the `word-break` property.
+///   Value for the `word-break` property.
 ///
 /// @example scss
-/// .wrapper {
-///   @include word-wrap(break-word);
-/// }
+///   .wrapper {
+///     @include word-wrap(break-word);
+///   }
 ///
 /// @example css
-/// .wrapper {
-///   overflow-wrap: break-word;
-///   word-break: break-all;
-///   word-wrap: break-word;
-/// }
+///   .wrapper {
+///     overflow-wrap: break-word;
+///     word-break: break-all;
+///     word-wrap: break-word;
+///   }
 
 @mixin word-wrap($wrap: break-word) {
   overflow-wrap: $wrap;

--- a/core/bourbon/css3/_font-face.scss
+++ b/core/bourbon/css3/_font-face.scss
@@ -1,27 +1,35 @@
 @charset "UTF-8";
 
-/// Generates an @font-face declaration. Accepts arugments for weight, style, usage with the Rails Asset Pipeline and file formats.
+/// Generates an @font-face declaration. Accepts arugments for weight, style,
+/// usage with the Rails Asset Pipeline and file formats.
 ///
 /// @argument {string} $font-family
+///
 /// @argument {string} $file-path
+///
 /// @argument {string} $weight [normal]
+///
 /// @argument {string} $asset-pipeline [$asset-pipeline]
-/// `$asset-pipeline` is set to `false` by default. You can pass in `true` to use the Rails Asset Pipeline (place the fonts in `app/assets/fonts/').
+///   `$asset-pipeline` is set to `false` by default. You can pass in `true` to
+///   use the Rails Asset Pipeline (place the fonts in `app/assets/fonts/').
+///
 /// @argument {list} $file-formats [$global-font-file-formats]
-/// `$global-font-file-formats` is set to `ttf woff2 woff` by default. Pass a list of file formats to support. E.g. `eot woff2 woff ttf svg`.
+///   `$global-font-file-formats` is set to `ttf woff2 woff` by default. Pass a
+///   list of file formats to support. E.g. `eot woff2 woff ttf svg`.
 ///
 /// @example scss
-/// @include font-face("source-sans-pro", "source-sans-pro/source-sans-pro-regular", normal, $asset-pipeline: true, $file-formats: eot woff ttf);
+///   @include font-face("source-sans-pro", "source-sans-pro/source-sans-pro-regular", normal, $asset-pipeline: true, $file-formats: eot woff ttf);
 ///
 /// @example css
-/// @font-face {
-///   font-family: "source-sans-pro";
-///   font-style: normal;
-///   font-weight: normal;
-///   src: font-url("source-sans-pro/source-sans-pro-regular.eot?#iefix") format("embedded-opentype"), font-url("source-sans-pro/source-sans-pro-regular.woff") format("woff"), font-url("source-sans-pro/source-sans-pro-regular.ttf") format("truetype");
-/// }
+///   @font-face {
+///     font-family: "source-sans-pro";
+///     font-style: normal;
+///     font-weight: normal;
+///     src: font-url("source-sans-pro/source-sans-pro-regular.eot?#iefix") format("embedded-opentype"), font-url("source-sans-pro/source-sans-pro-regular.woff") format("woff"), font-url("source-sans-pro/source-sans-pro-regular.ttf") format("truetype");
+///   }
 ///
 /// @require {function} font-url-prefixer
+///
 /// @require {function} font-source-declaration
 
 @mixin font-face(

--- a/core/bourbon/functions/_assign-inputs.scss
+++ b/core/bourbon/functions/_assign-inputs.scss
@@ -5,10 +5,10 @@
 /// @access private
 ///
 /// @argument {list | string} $inputs
-/// A selector, or list of selectors, to apply the pseudo-class to
+///   A selector, or list of selectors, to apply the pseudo-class to
 ///
 /// @argument {pseudo-class} $pseudo [null]
-/// The pseudo-class to be appended
+///   The pseudo-class to be appended
 ///
 /// @return {list}
 

--- a/core/bourbon/functions/_contains-falsy.scss
+++ b/core/bourbon/functions/_contains-falsy.scss
@@ -5,7 +5,7 @@
 /// @access private
 ///
 /// @argument {list} $list
-/// The list to check against.
+///   The list to check against.
 ///
 /// @return {boolean}
 

--- a/core/bourbon/functions/_contains.scss
+++ b/core/bourbon/functions/_contains.scss
@@ -5,10 +5,10 @@
 /// @access private
 ///
 /// @argument {list} $list
-/// The list to check against.
+///   The list to check against.
 ///
 /// @argument {list} $values
-/// A single value or list of values to check for.
+///   A single value or list of values to check for.
 ///
 /// @return {boolean}
 

--- a/core/bourbon/functions/_is-light.scss
+++ b/core/bourbon/functions/_is-light.scss
@@ -7,7 +7,7 @@
 /// @argument {color (hex)} $hex-color
 ///
 /// @example scss
-/// is-light($color)
+///   is-light($color)
 ///
 /// @return {boolean}
 

--- a/core/bourbon/functions/_modular-scale.scss
+++ b/core/bourbon/functions/_modular-scale.scss
@@ -1,50 +1,53 @@
 @charset "UTF-8";
 
-/// Increments up or down a defined scale and returns an adjusted value. This helps establish consistent measurements and spacial relationships throughout your project. We provide a list of commonly used scales as [pre-defined variables](//github.com/thoughtbot/bourbon/blob/master/core/settings/_scales.scss).
+/// Increments up or down a defined scale and returns an adjusted value. This
+/// helps establish consistent measurements and spacial relationships throughout
+/// your project. We provide a list of commonly used scales as
+/// [pre-defined variables](//github.com/thoughtbot/bourbon/blob/master/core/settings/_scales.scss).
 ///
 /// @argument {number} $increment
-/// How many steps to increment up or down the scale
+///   How many steps to increment up or down the scale
 ///
 /// @argument {number} $value [$modular-scale-base (1em)]
-/// The base value the scale starts at
+///   The base value the scale starts at
 ///
 /// @argument {number} $ratio [$modular-scale-ratio (1.25)]
-/// The ratio the scale is built on
+///   The ratio the scale is built on
 ///
 /// @example scss
-/// .first-element {
-///   font-size: modular-scale(2);
-/// }
+///   .first-element {
+///     font-size: modular-scale(2);
+///   }
 ///
-/// .second-element {
-///   margin-right: modular-scale(3, 2em);
-/// }
+///   .second-element {
+///     margin-right: modular-scale(3, 2em);
+///   }
 ///
-/// .third-element {
-///   font-size: modular-scale(3, 1em 1.6em, $major-seventh);
-/// }
+///   .third-element {
+///     font-size: modular-scale(3, 1em 1.6em, $major-seventh);
+///   }
 ///
-/// $modular-scale-ratio: 1.2; // change the base ratio
-/// .fourth-element {
-///   font-size: modular-scale(3);
-/// }
+///   $modular-scale-ratio: 1.2; // change the base ratio
+///   .fourth-element {
+///     font-size: modular-scale(3);
+///   }
 ///
 /// @example css
-/// .first-element {
-///   font-size: 1.5625em;
-/// }
+///   .first-element {
+///     font-size: 1.5625em;
+///   }
 ///
-/// .second-element {
-///   margin-right: 3.90625em;
-/// }
+///   .second-element {
+///     margin-right: 3.90625em;
+///   }
 ///
-/// .third-element {
-///   font-size: 3em;
-/// }
+///   .third-element {
+///     font-size: 3em;
+///   }
 ///
-/// .fourth-element {
-///   font-size: 1.728em;
-/// }
+///   .fourth-element {
+///     font-size: 1.728em;
+///   }
 ///
 /// @return {number}
 ///

--- a/core/bourbon/functions/_shade.scss
+++ b/core/bourbon/functions/_shade.scss
@@ -5,17 +5,17 @@
 /// @argument {color} $color
 ///
 /// @argument {number (percentage)} $percent
-/// The amount of black to be mixed in.
+///   The amount of black to be mixed in.
 ///
 /// @example scss
-/// .element {
-///   background-color: shade(#ffbb52, 60%);
-/// }
+///   .element {
+///     background-color: shade(#ffbb52, 60%);
+///   }
 ///
 /// @example css
-/// .element {
-///   background-color: #664a20;
-/// }
+///   .element {
+///     background-color: #664a20;
+///   }
 ///
 /// @return {color}
 

--- a/core/bourbon/functions/_strip-unit.scss
+++ b/core/bourbon/functions/_strip-unit.scss
@@ -5,10 +5,10 @@
 /// @argument {number} $value
 ///
 /// @example scss
-/// $dimension: strip-unit(10em);
+///   $dimension: strip-unit(10em);
 ///
 /// @example css
-/// $dimension: 10;
+///   $dimension: 10;
 ///
 /// @return {number}
 

--- a/core/bourbon/functions/_tint.scss
+++ b/core/bourbon/functions/_tint.scss
@@ -5,17 +5,17 @@
 /// @argument {color} $color
 ///
 /// @argument {number (percentage)} $percent
-/// The amount of white to be mixed in.
+///   The amount of white to be mixed in.
 ///
 /// @example scss
-/// .element {
-///   background-color: tint(#6ecaa6, 40%);
-/// }
+///   .element {
+///     background-color: tint(#6ecaa6, 40%);
+///   }
 ///
 /// @example css
-/// .element {
-///   background-color: #a8dfc9;
-/// }
+///   .element {
+///     background-color: #a8dfc9;
+///   }
 ///
 /// @return {color}
 

--- a/core/bourbon/functions/_unpack.scss
+++ b/core/bourbon/functions/_unpack.scss
@@ -7,14 +7,14 @@
 /// @argument {list} $shorthand
 ///
 /// @example scss
-/// .element {
-///   margin: unpack(1em 2em);
-/// }
+///   .element {
+///     margin: unpack(1em 2em);
+///   }
 ///
 /// @example css
-/// .element {
-///   margin: 1em 2em 1em 2em;
-/// }
+///   .element {
+///     margin: 1em 2em 1em 2em;
+///   }
 
 @function unpack($shorthand) {
   @if length($shorthand) == 1 {

--- a/core/bourbon/helpers/_directional-values.scss
+++ b/core/bourbon/helpers/_directional-values.scss
@@ -1,6 +1,7 @@
 @charset "UTF-8";
 
-/// Directional-property mixins are shorthands for writing properties like the following
+/// Directional-property mixins are shorthands for writing properties like
+/// the following
 ///
 /// @ignore You can also use `false` instead of `null`.
 ///

--- a/core/bourbon/settings/_global-font-file-formats.scss
+++ b/core/bourbon/settings/_global-font-file-formats.scss
@@ -5,7 +5,7 @@
 /// @see {mixin} font-face
 ///
 /// @example scss
-/// $global-font-file-formats: woff2 woff;
+///   $global-font-file-formats: woff2 woff;
 ///
 /// @type list | string
 


### PR DESCRIPTION
As of v2.1.10, SassDoc now strips the required indentation for examples when it
parses the comments.

This commit also break description lines at 80 characters