### PR TITLE
Fix SCSS-Lint errors

### DIFF
--- a/core/bourbon/helpers/_directional-values.scss
+++ b/core/bourbon/helpers/_directional-values.scss
@@ -65,7 +65,7 @@
 /// @require {function} contains-falsy
 
 @mixin directional-property($pre, $suf, $values) {
-  // Property Names
+  // scss-lint:disable SpaceAroundOperator
   $top:    $pre + "-top"    + if($suf, "-#{$suf}", "");
   $bottom: $pre + "-bottom" + if($suf, "-#{$suf}", "");
   $left:   $pre + "-left"   + if($suf, "-#{$suf}", "");

--- a/spec/bourbon/addons/border_color_spec.rb
+++ b/spec/bourbon/addons/border_color_spec.rb
@@ -7,7 +7,7 @@ describe "border-color" do
 
   context "called with one color" do
     it "applies same color to all sides" do
-      rule = "border-color: #ff0000"
+      rule = "border-color: #f00"
 
       expect(".border-color-all").to have_rule(rule)
     end
@@ -15,7 +15,7 @@ describe "border-color" do
 
   context "called with two colors" do
     it "applies to alternating sides" do
-      rule = "border-color: #00ff00 #0000ff"
+      rule = "border-color: #0f0 #00f"
 
       expect(".border-color-alternate").to have_rule(rule)
     end
@@ -23,7 +23,7 @@ describe "border-color" do
 
   context "called with three colors" do
     it "applies second color to left and right" do
-      rule = "border-color: #ff0000 #00ff00 #0000ff"
+      rule = "border-color: #f00 #0f0 #00f"
 
       expect(".border-color-implied-left").to have_rule(rule)
     end
@@ -31,7 +31,7 @@ describe "border-color" do
 
   context "called with four colors" do
     it "applies different colors to all sides" do
-      rule = "border-color: #0000ff #00ff00 #ff0000 #ffff00"
+      rule = "border-color: #00f #0f0 #f00 #ff0"
 
       expect(".border-color-explicit").to have_rule(rule)
     end
@@ -39,9 +39,9 @@ describe "border-color" do
 
   context "called with null values" do
     it "writes rules for other three" do
-      ruleset = "border-top-color: #00ff00; " +
-                "border-right-color: #ffff00; " +
-                "border-left-color: #0000ff;"
+      ruleset = "border-top-color: #0f0; " +
+                "border-right-color: #ff0; " +
+                "border-left-color: #00f;"
       bad_rule = "border-bottom-color: null;"
 
       expect(".border-color-false-third").to have_ruleset(ruleset)

--- a/spec/bourbon/functions/assign_inputs_spec.rb
+++ b/spec/bourbon/functions/assign_inputs_spec.rb
@@ -13,7 +13,7 @@ describe "assign-inputs" do
   context "expands plain text inputs" do
     it "finds selectors" do
       @text_inputs_list.each do |input|
-        expect(input).to have_rule("color: #ff0000")
+        expect(input).to have_rule("color: #f00")
       end
     end
   end
@@ -23,7 +23,7 @@ describe "assign-inputs" do
       list = @text_inputs_list.dup
       list.map! { |input| input + ":active" }
       list.each do |input|
-        expect(input).to have_rule("color: #00ff00")
+        expect(input).to have_rule("color: #0f0")
       end
     end
   end
@@ -33,7 +33,7 @@ describe "assign-inputs" do
       list = @text_inputs_list.dup
       list.push "select"
       list.each do |input|
-        expect(input).to have_rule("color: #0000ff")
+        expect(input).to have_rule("color: #00f")
       end
     end
   end
@@ -43,7 +43,7 @@ describe "assign-inputs" do
       list = @text_inputs_list.dup
       list.unshift "[type=\"file\"]"
       list.each do |input|
-        expect(input).to have_rule("color: #ff00ff")
+        expect(input).to have_rule("color: #f0f")
       end
     end
   end

--- a/spec/bourbon/helpers/directional_values_spec.rb
+++ b/spec/bourbon/helpers/directional_values_spec.rb
@@ -33,7 +33,7 @@ describe "directional-values" do
     end
 
     it "returns property and value with vertical and horizontal values" do
-      expect(".border-color").to have_rule("border-color: #ffffff #000000")
+      expect(".border-color").to have_rule("border-color: #fff #000")
     end
   end
 end

--- a/spec/fixtures/addons/border-color.scss
+++ b/spec/fixtures/addons/border-color.scss
@@ -1,9 +1,9 @@
 @import "setup";
 
-$red: #ff0000;
-$blue: #00ff00;
-$green: #0000ff;
-$purple: #ffff00;
+$red: #f00;
+$blue: #0f0;
+$green: #00f;
+$purple: #ff0;
 
 .border-color-all {
   @include border-color($red);

--- a/spec/fixtures/functions/assign-inputs.scss
+++ b/spec/fixtures/functions/assign-inputs.scss
@@ -1,19 +1,19 @@
 @import "setup";
 
 #{assign-inputs($text-inputs-list)} {
-  color: #ff0000;
+  color: #f00;
 }
 
 #{assign-inputs($text-inputs-list, active)} {
-  color: #00ff00;
+  color: #0f0;
 }
 
 #{assign-inputs($text-inputs-list)},
 select {
-  color: #0000ff;
+  color: #00f;
 }
 
 [type="file"],
 #{assign-inputs($text-inputs-list)} {
-  color: #ff00ff;
+  color: #f0f;
 }

--- a/spec/fixtures/functions/is-light.scss
+++ b/spec/fixtures/functions/is-light.scss
@@ -9,11 +9,11 @@
 }
 
 .pink {
-  @include reverse-color(#ffcccc);
+  @include reverse-color(#fcc);
 }
 
 .sky {
-  @include reverse-color(#aaeeff);
+  @include reverse-color(#aef);
 }
 
 .medium-gray {

--- a/spec/fixtures/functions/shade.scss
+++ b/spec/fixtures/functions/shade.scss
@@ -9,7 +9,7 @@
 }
 
 .shade-red {
-  color: shade(#ff0000, 25%);
+  color: shade(#f00, 25%);
 }
 
 .shade-gray {

--- a/spec/fixtures/functions/tint.scss
+++ b/spec/fixtures/functions/tint.scss
@@ -9,7 +9,7 @@
 }
 
 .tint-red {
-  color: tint(#ff0000, 25%);
+  color: tint(#f00, 25%);
 }
 
 .tint-gray {

--- a/spec/fixtures/helpers/directional-values.scss
+++ b/spec/fixtures/helpers/directional-values.scss
@@ -25,5 +25,5 @@
 }
 
 .border-color {
-  @include directional-property(border, color, #ffffff #000000);
+  @include directional-property(border, color, #fff #000);
 }


### PR DESCRIPTION
Errors being resolved with this PR:

```
core/bourbon/helpers/_directional-values.scss:68 [W] SpaceAroundOperator: `$pre + "-top"    + if($suf, "-#{$suf}", "")` should be written with a single space on each side of the operator: `$pre + "-top"  + if($suf, "-#{$suf}", "")`
core/bourbon/helpers/_directional-values.scss:70 [W] SpaceAroundOperator: `$pre + "-left"   + if($suf, "-#{$suf}", "")` should be written with a single space on each side of the operator: `$pre + "-left"  + if($suf, "-#{$suf}", "")`
core/bourbon/helpers/_directional-values.scss:71 [W] SpaceAroundOperator: `$pre + "-right"  + if($suf, "-#{$suf}", "")` should be written with a single space on each side of the operator: `$pre + "-right"  + if($suf, "-#{$suf}", "")`
core/bourbon/helpers/_directional-values.scss:72 [W] SpaceAroundOperator: `$pre +             if($suf, "-#{$suf}", "")` should be written with a single space on each side of the operator: `$pre + if($suf, "-#{$suf}", "")`
spec/fixtures/addons/border-color.scss:3 [W] HexLength: Color `#ff0000` should be written as `#f00`
spec/fixtures/addons/border-color.scss:4 [W] HexLength: Color `#00ff00` should be written as `#0f0`
spec/fixtures/addons/border-color.scss:5 [W] HexLength: Color `#0000ff` should be written as `#00f`
spec/fixtures/addons/border-color.scss:6 [W] HexLength: Color `#ffff00` should be written as `#ff0`
spec/fixtures/functions/assign-inputs.scss:4 [W] HexLength: Color `#ff0000` should be written as `#f00`
spec/fixtures/functions/assign-inputs.scss:8 [W] HexLength: Color `#00ff00` should be written as `#0f0`
spec/fixtures/functions/assign-inputs.scss:13 [W] HexLength: Color `#0000ff` should be written as `#00f`
spec/fixtures/functions/assign-inputs.scss:18 [W] HexLength: Color `#ff00ff` should be written as `#f0f`
spec/fixtures/functions/is-light.scss:12 [W] HexLength: Color `#ffcccc` should be written as `#fcc`
spec/fixtures/functions/is-light.scss:16 [W] HexLength: Color `#aaeeff` should be written as `#aef`
spec/fixtures/functions/shade.scss:12 [W] HexLength: Color `#ff0000` should be written as `#f00`
spec/fixtures/functions/tint.scss:12 [W] HexLength: Color `#ff0000` should be written as `#f00`
spec/fixtures/helpers/directional-values.scss:28 [W] HexLength: Color `#ffffff` should be written as `#fff`
spec/fixtures/helpers/directional-values.scss:28 [W] HexLength: Color `#000000` should be written as `#000`
```