### PR TITLE
Use quotes around interpolation

### DIFF
--- a/app/assets/stylesheets/css3/_radial-gradient.scss
+++ b/app/assets/stylesheets/css3/_radial-gradient.scss
@@ -34,6 +34,6 @@
   $shape-size-spec: if(($shape-size-spec != " ") and ($pos == null), "#{$shape-size-spec}, ", "#{$shape-size-spec} ");
 
   background-color:  $fallback-color;
-  background-image: -webkit-radial-gradient(unquote(#{$pos}#{$shape-size}#{$full}));
-  background-image: unquote("radial-gradient(#{$shape-size-spec}#{$pos-spec}#{$full})");
+  background-image: -webkit-radial-gradient(#{$pos}#{$shape-size}#{$full});
+  background-image: radial-gradient(#{$shape-size-spec}#{$pos-spec}#{$full});
 }


### PR DESCRIPTION
This resolves a Sass deprecation warning for when using interpolation without quotes in certain ways.

More info: https://github.com/sass/sass/blob/3.4.20/doc-src/SASS_CHANGELOG.md#3420-09-december-2015

Fixes #810