### PR TITLE
Refactor clearfix mixin to use block display

### DIFF
--- a/core/bourbon/addons/_clearfix.scss
+++ b/core/bourbon/addons/_clearfix.scss
@@ -2,7 +2,7 @@
 
 /// Provides an easy way to include a clearfix for containing floats.
 ///
-/// @link http://goo.gl/0VEum5
+/// @link http://goo.gl/yP5hiZ
 ///
 /// @example scss
 ///   .element {
@@ -13,13 +13,13 @@
 ///   .element::after {
 ///     clear: both;
 ///     content: "";
-///     display: table;
+///     display: block;
 ///   }
 
 @mixin clearfix {
   &::after {
     clear: both;
     content: "";
-    display: table;
+    display: block;
   }
 }

--- a/spec/bourbon/addons/clearfix_spec.rb
+++ b/spec/bourbon/addons/clearfix_spec.rb
@@ -9,8 +9,8 @@ describe "clearfix" do
     it "adds clearfix" do
       input = ".clearfix::after"
       ruleset = "clear: both; " +
-                "content: \"\"; " +
-                "display: table;"
+                'content: ""; ' +
+                "display: block;"
 
       expect(input).to have_ruleset(ruleset)
     end


### PR DESCRIPTION
The presence of `display: table` is part of an accommodation for multiple
vertical margins attempting to collapse in to each other. To preserve more
standard functionality, it is preferred that the object is clearfixed without
effecting margin behavior.

See: http://cssmojo.com/the-very-latest-clearfix-reloaded