### PR TITLE
Paths

### DIFF
--- a/bin/bourbon
+++ b/bin/bourbon
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
 
-# CodeKit needs relative paths
-require File.dirname(__FILE__) + '/../lib/bourbon.rb'
+require File.dirname(__FILE__) + "/../lib/bourbon.rb"
 
 Bourbon::Generator.start

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
-var path = require('path');
+var path = require("path");
 
 module.exports = {
   includePaths: [
-    path.join(__dirname, 'core')
+    path.join(__dirname, "core")
   ]
 };

--- a/lib/bourbon.rb
+++ b/lib/bourbon.rb
@@ -4,10 +4,6 @@ $LOAD_PATH.unshift dir unless $LOAD_PATH.include?(dir)
 
 require "bourbon/generator"
 
-unless defined?(Sass)
-  require 'sass'
-end
-
 module Bourbon
   if defined?(Rails) && defined?(Rails::Engine)
     class Engine < ::Rails::Engine

--- a/lib/bourbon.rb
+++ b/lib/bourbon.rb
@@ -11,7 +11,7 @@ end
 module Bourbon
   if defined?(Rails) && defined?(Rails::Engine)
     class Engine < ::Rails::Engine
-      require 'bourbon/engine'
+      require "bourbon/engine"
     end
 
     module Rails
@@ -22,7 +22,7 @@ module Bourbon
       end
     end
   else
-    bourbon_path = File.expand_path("../../app/assets/stylesheets", __FILE__)
+    bourbon_path = File.expand_path("../../core", __FILE__)
     ENV["SASS_PATH"] = [ENV["SASS_PATH"], bourbon_path].compact.join(File::PATH_SEPARATOR)
   end
 end

--- a/lib/bourbon.rb
+++ b/lib/bourbon.rb
@@ -1,7 +1,3 @@
-# CodeKit needs relative paths
-dir = File.dirname(__FILE__)
-$LOAD_PATH.unshift dir unless $LOAD_PATH.include?(dir)
-
 require "bourbon/generator"
 
 module Bourbon

--- a/lib/bourbon/generator.rb
+++ b/lib/bourbon/generator.rb
@@ -1,12 +1,12 @@
-require 'bourbon/version'
+require "bourbon/version"
 require "fileutils"
-require 'thor'
+require "thor"
 
 module Bourbon
   class Generator < Thor
-    map ['-v', '--version'] => :version
+    map ["-v", "--version"] => :version
 
-    desc 'install', 'Install Bourbon into your project'
+    desc "install", "Install Bourbon into your project"
     method_options :path => :string, :force => :boolean
     def install
       if bourbon_files_already_exist? && !options[:force]
@@ -17,7 +17,7 @@ module Bourbon
       end
     end
 
-    desc 'update', 'Update Bourbon'
+    desc "update", "Update Bourbon"
     method_options :path => :string
     def update
       if bourbon_files_already_exist?
@@ -29,7 +29,7 @@ module Bourbon
       end
     end
 
-    desc 'version', 'Show Bourbon version'
+    desc "version", "Show Bourbon version"
     def version
       say "Bourbon #{Bourbon::VERSION}"
     end
@@ -42,9 +42,9 @@ module Bourbon
 
     def install_path
       @install_path ||= if options[:path]
-          Pathname.new(File.join(options[:path], 'bourbon'))
+          Pathname.new(File.join(options[:path], "bourbon"))
         else
-          Pathname.new('bourbon')
+          Pathname.new("bourbon")
         end
     end
 


### PR DESCRIPTION
- We moved away from `app/assets/stylesheets/` and starting using a `core/` directory in c76215b, but forgot to update the path in `lib/bourbon.rb`
  - This fixes an error that currently exists on `master`, in which you will get an error when trying to import Bourbon: `Error: File to import not found or unreadable: bourbon.`
- This PR is also an attempt to reduce unnecessary nuances to the codebase between Bourbon and Neat. Neat has none of the deletions found in this PR and all seems fine without it.