### PR TITLE
`contrast-switch` Updates

### DIFF
--- a/core/bourbon/addons/_contrast-switch.scss
+++ b/core/bourbon/addons/_contrast-switch.scss
@@ -39,8 +39,8 @@
 
 @function contrast-switch(
     $base-color,
-    $dark-color: #000,
-    $light-color: #fff
+    $dark-color: _bourbon-get-setting("contrast-switch-dark-color"),
+    $light-color: _bourbon-get-setting("contrast-switch-light-color")
   ) {
 
   @return if(is-light($base-color), $dark-color, $light-color);

--- a/core/bourbon/addons/_contrast-switch.scss
+++ b/core/bourbon/addons/_contrast-switch.scss
@@ -4,13 +4,13 @@
 /// for building button styles.
 ///
 /// @argument {color} $base-color
-///   The `color` to evaluate lightness against.
+///   The color to evaluate lightness against.
 ///
-/// @argument {color} $light-color [#000]
-///   The `color` to be output when `base-color` is light.
+/// @argument {color} $dark-color [#000]
+///   The color to be output when `$base-color` is light.
 ///
-/// @argument {color} $dark-color [#fff]
-///   The `color` to be output when `base-color` is dark.
+/// @argument {color} $light-color [#fff]
+///   The color to be output when `$base-color` is dark.
 ///
 /// @example scss
 ///   .first-element {
@@ -39,9 +39,9 @@
 
 @function contrast-switch(
     $base-color,
-    $light-color: #000,
-    $dark-color: #fff
+    $dark-color: #000,
+    $light-color: #fff
   ) {
 
-  @return if(is-light($base-color), $light-color, $dark-color);
+  @return if(is-light($base-color), $dark-color, $light-color);
 }

--- a/core/bourbon/settings/_settings.scss
+++ b/core/bourbon/settings/_settings.scss
@@ -4,6 +4,12 @@
 ///
 /// @type map
 ///
+/// @property {color} contrast-switch-dark-color [#000]
+///   Global dark color for the `contrast-switch` function.
+///
+/// @property {color} contrast-switch-light-color [#fff]
+///   Global light color for the `contrast-switch` function.
+///
 /// @property {list} global-font-file-formats [("ttf", "woff2", "woff")]
 ///   Global font file formats for the `font-face` mixin.
 ///
@@ -20,6 +26,8 @@
 /// @access private
 
 $_bourbon-defaults: (
+  "contrast-switch-dark-color": #000,
+  "contrast-switch-light-color": #fff,
   "global-font-file-formats": ("ttf", "woff2", "woff"),
   "modular-scale-base": 1em,
   "modular-scale-ratio": $major-third,


### PR DESCRIPTION
- Change `contrast-switch` argument names
  - This makes the name of the argument in line with the color it is outputting, rather than the color of the base, which didn't make sense.
- Add global settings for `contrast-switch` colors

cc: @whmii @ethangl 