### PR TITLE
Add pathname requirement to resolve install issues

### DIFF
--- a/lib/bourbon/generator.rb
+++ b/lib/bourbon/generator.rb
@@ -1,6 +1,7 @@
 require "bourbon/version"
 require "fileutils"
 require "thor"
+require "pathname"
 
 module Bourbon
   class Generator < Thor


### PR DESCRIPTION
The bourbon CLI depends on `Pathname`, however it is not actually being
required anywhere. The test suite presumably passes because it pathname
is required by a test dependency.