### PR TITLE
Re-order font-face mixin arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ project adheres to [Semantic Versioning](http://semver.org).
 
 [Unreleased]: https://github.com/thoughtbot/bourbon/compare/v5.0.0.beta.4...HEAD
 
+### Changed
+
+- Swapped the order of the `$file-formats` and `$asset-pipeline` arguments in
+  the `font-face` mixin, so that `$asset-pipeline` is last (because it has a
+  default and is likely used the least).
+
 ## [5.0.0-beta.4] - 2016-03-11
 
 ### Fixed

--- a/core/bourbon/library/_font-face.scss
+++ b/core/bourbon/library/_font-face.scss
@@ -43,8 +43,8 @@
 @mixin font-face(
     $font-family,
     $file-path,
-    $asset-pipeline: _bourbon-get-setting("rails-asset-pipeline"),
-    $file-formats: _bourbon-get-setting("global-font-file-formats")
+    $file-formats: _bourbon-get-setting("global-font-file-formats"),
+    $asset-pipeline: _bourbon-get-setting("rails-asset-pipeline")
   ) {
 
   @font-face {

--- a/spec/fixtures/library/font-face-3.scss
+++ b/spec/fixtures/library/font-face-3.scss
@@ -3,6 +3,6 @@
 @include font-face(
   "pitch",
   "/fonts/pitch",
-  true,
-  "woff2"
+  "woff2",
+  $asset-pipeline: true
 );

--- a/spec/fixtures/library/font-face-4.scss
+++ b/spec/fixtures/library/font-face-4.scss
@@ -3,5 +3,5 @@
 @include font-face(
   "circular",
   "/circular",
-  $file-formats: ("woff2", "svg")
+  ("woff2", "svg")
 );


### PR DESCRIPTION
Swap `$file-formats` and `$asset-pipeline` so that `$asset-pipeline` is last because it is likely used the least.

This means you would be able to write it a bit more succinctly:

```diff
@include font-face(
  "source-sans-pro",
  "fonts/source-sans-pro-regular",
- $file-formats: "woff2"
+ "woff2"
);
```