### PR TITLE
Revert back to the previous Sass path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ project adheres to [Semantic Versioning](http://semver.org).
 
 [Unreleased]: https://github.com/thoughtbot/bourbon/compare/v5.0.0.beta.4...HEAD
 
+### Fixed
+
+- Fixed a Sass load path issue that would intermittently break the importing of
+  Bourbon in Rails apps.
+
 ### Changed
 
 - Swapped the order of the `$file-formats` and `$asset-pipeline` arguments in

--- a/lib/bourbon.rb
+++ b/lib/bourbon.rb
@@ -1,4 +1,7 @@
 require "bourbon/generator"
 
 bourbon_path = File.expand_path("../../core", __FILE__)
-ENV["SASS_PATH"] = File.join([ENV["SASS_PATH"], bourbon_path].compact)
+ENV["SASS_PATH"] = [
+  ENV["SASS_PATH"],
+  bourbon_path,
+].compact.join(File::PATH_SEPARATOR)


### PR DESCRIPTION
We’ve had multiple reports of failure importing Bourbon, specifically within Rails apps:

```
Failure/Error: @import "bourbon";

     ActionView::Template::Error:
       File to import not found or unreadable: bourbon.
       Load paths:
         /home/ubuntu/bungalow/vendor/bundle/ruby/2.3.0/gems/babel-source-5.8.35/lib
         /home/ubuntu/bungalow/app/assets/images
         /home/ubuntu/bungalow/app/assets/javascripts
         /home/ubuntu/bungalow/app/assets/stylesheets
         /home/ubuntu/bungalow/vendor/assets/javascripts
         /home/ubuntu/bungalow/vendor/assets/stylesheets
         /home/ubuntu/bungalow/vendor/bundle/ruby/2.3.0/gems/normalize-rails-3.0.3/vendor/assets/stylesheets
         /home/ubuntu/bungalow/vendor/bundle/ruby/2.3.0/gems/jquery-rails-4.1.1/vendor/assets/javascripts
         /home/ubuntu/bungalow/vendor/bundle/ruby/2.3.0/gems/bourbon-5.0.0.beta.4/core/home/ubuntu/bungalow/vendor/bundle/ruby/2.3.0/gems/bourbon-5.0.0.beta.4/core
```

Related: https://github.com/thoughtbot/suspenders/issues/727
