### PR TITLE
Add composer.json for convenient use with PHP apps

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,6 +7,7 @@ bin/
 bourbon.gemspec
 bower.json
 circle.yml
+composer.json
 features/
 Gemfile
 Gemfile.lock

--- a/bower.json
+++ b/bower.json
@@ -9,6 +9,7 @@
     "_site",
     "bin",
     "bourbon.gemspec",
+    "composer.json",
     "eyeglass-exports.js",
     "features",
     "Gemfile",

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,18 @@
+{
+    "name": "thoughtbot/bourbon",
+    "description": "A simple and lightweight mixin library for Sass.",
+    "license": "MIT",
+    "homepage": "http://bourbon.io",
+    "keywords": [
+        "css",
+        "mixins",
+        "sass",
+        "scss"
+    ],
+    "authors": [
+        {
+            "name": "thoughtbot",
+            "homepage": "http://thoughtbot.com"
+        }
+    ]
+}


### PR DESCRIPTION
This allows PHP based apps to require Bourbon conveniently via their composer file and use it as such: `scss --load-path vendor/thoughtbot/bourbon/core some-stylesheet.scss`.

For more info on composer: http://getcomposer.org/

If this PR is approved, Bourbon should be submitted to https://packagist.org.