### PR TITLE
Remove View More link

### DIFF
--- a/index.html
+++ b/index.html
@@ -247,7 +247,6 @@ $ bourbon update
   <section class="websites">
     <div class="container">
       <h3>Who’s using it?</h3>
-      <p><a href="//github.com/thoughtbot/bourbon/wiki/Projects-and-Companies-using-Bourbon">View More &raquo;</a></p>
       <a class="website yourgrind" href="//yourgrind.com"><img src="../images/marketing/yourgrind.png" alt="YourGrind website screenshot"></a>
       <a class="website fdn" href="//gofdn.com"><img src="../images/marketing/fdn.png" alt="FDN website screenshot"></a>
       <a class="website edge" href="//usetakana.com/"><img src="../images/marketing/edge.png" alt="Takana website screenshot"></a>


### PR DESCRIPTION
This hasn't been maintained, so the GitHub Wiki page was removed. We're also
working on a new website for the 5.0 release, so just removing this for now is
the quickest win currently.

Closes #884