### PR TITLE
Add deprecation warnings

### DIFF
--- a/app/assets/stylesheets/_bourbon-deprecate.scss
+++ b/app/assets/stylesheets/_bourbon-deprecate.scss
@@ -8,12 +8,12 @@
 @mixin _bourbon-deprecate($feature, $message: null) {
   @if $output-bourbon-deprecation-warnings == true {
     @warn "[Bourbon] [Deprecation] `#{$feature}` is deprecated and will be " +
-      "removed in 5.0.0. #{$message}.";
+      "removed in 5.0.0. #{$message}";
     @content;
   }
 }
 
 @mixin _bourbon-deprecate-for-prefixing($feature) {
   @include _bourbon-deprecate($feature, "We suggest using an automated " +
-    "prefixing tool, like Autoprefixer");
+    "prefixing tool, like Autoprefixer.");
 }

--- a/app/assets/stylesheets/_bourbon-deprecate.scss
+++ b/app/assets/stylesheets/_bourbon-deprecate.scss
@@ -1,0 +1,19 @@
+@charset "UTF-8";
+
+/// Throws Sass warnings to announce library deprecations. You can disable them
+/// by setting the `$output-bourbon-deprecation-warnings` variable to `false`.
+///
+/// @access private
+
+@mixin _bourbon-deprecate($feature, $message: null) {
+  @if $output-bourbon-deprecation-warnings == true {
+    @warn "[Bourbon] [Deprecation] `#{$feature}` is deprecated and will be " +
+      "removed in 5.0.0. #{$message}.";
+    @content;
+  }
+}
+
+@mixin _bourbon-deprecate-for-prefixing($feature) {
+  @include _bourbon-deprecate($feature, "We suggest using an automated " +
+    "prefixing tool, like Autoprefixer");
+}

--- a/app/assets/stylesheets/_bourbon-deprecated-upcoming.scss
+++ b/app/assets/stylesheets/_bourbon-deprecated-upcoming.scss
@@ -1,12 +1,13 @@
 // The following features have been deprecated and will be removed in the next MAJOR version release
 
 @mixin inline-block {
-  display: inline-block;
+  @include _bourbon-deprecate("inline-block");
 
-  @warn "The inline-block mixin is deprecated and will be removed in the next major version release";
+  display: inline-block;
 }
 
 @mixin button ($style: simple, $base-color: #4294f0, $text-size: inherit, $padding: 7px 18px) {
+  @include _bourbon-deprecate("button");
 
   @if type-of($style) == string and type-of($base-color) == color {
     @include buttonstyle($style, $base-color, $text-size, $padding);
@@ -60,8 +61,6 @@
     cursor: not-allowed;
     opacity: 0.5;
   }
-
-  @warn "The button mixin is deprecated and will be removed in the next major version release";
 }
 
 // Selector Style Button
@@ -377,35 +376,50 @@
 
 // Flexible grid
 @function flex-grid($columns, $container-columns: $fg-max-columns) {
+  @if $output-bourbon-deprecation-warnings == true {
+    @warn "[Bourbon] [Deprecation] `flex-grid` is deprecated and will be " +
+    "removed in 5.0.0. For grid functions, check out Bourbon's sister library" +
+    "Neat.";
+  }
+
   $width: $columns * $fg-column + ($columns - 1) * $fg-gutter;
   $container-width: $container-columns * $fg-column + ($container-columns - 1) * $fg-gutter;
   @return percentage($width / $container-width);
-
-  @warn "The flex-grid function is deprecated and will be removed in the next major version release";
 }
 
 // Flexible gutter
 @function flex-gutter($container-columns: $fg-max-columns, $gutter: $fg-gutter) {
+  @if $output-bourbon-deprecation-warnings == true {
+    @warn "[Bourbon] [Deprecation] `flex-gutter` is deprecated and will be " +
+    "removed in 5.0.0. For grid functions, check out Bourbon's sister library" +
+    "Neat.";
+  }
+
   $container-width: $container-columns * $fg-column + ($container-columns - 1) * $fg-gutter;
   @return percentage($gutter / $container-width);
-
-  @warn "The flex-gutter function is deprecated and will be removed in the next major version release";
 }
 
 @function grid-width($n) {
-  @return $n * $gw-column + ($n - 1) * $gw-gutter;
+  @if $output-bourbon-deprecation-warnings == true {
+    @warn "[Bourbon] [Deprecation] `grid-width` is deprecated and will be " +
+    "removed in 5.0.0. For grid functions, check out Bourbon's sister library" +
+    "Neat.";
+  }
 
-  @warn "The grid-width function is deprecated and will be removed in the next major version release";
+  @return $n * $gw-column + ($n - 1) * $gw-gutter;
 }
 
 @function golden-ratio($value, $increment) {
-  @return modular-scale($increment, $value, $ratio: $golden);
+  @if $output-bourbon-deprecation-warnings == true {
+    @warn "[Bourbon] [Deprecation] `golden-ratio` is deprecated and will be " +
+    "removed in 5.0.0. You can use the `modular-scale` function instead.";
+  }
 
-  @warn "The golden-ratio function is deprecated and will be removed in the next major version release. Please use the modular-scale function, instead.";
+  @return modular-scale($increment, $value, $ratio: $golden);
 }
 
 @mixin box-sizing($box) {
-  @include prefixer(box-sizing, $box, webkit moz spec);
+  @include _bourbon-deprecate-for-prefixing("box-sizing");
 
-  @warn "The box-sizing mixin is deprecated and will be removed in the next major version release. This property can now be used un-prefixed.";
+  @include prefixer(box-sizing, $box, webkit moz spec);
 }

--- a/app/assets/stylesheets/_bourbon.scss
+++ b/app/assets/stylesheets/_bourbon.scss
@@ -3,9 +3,12 @@
 // Copyright 2011-2015 thoughtbot, inc.
 // MIT License
 
+@import "settings/disable-warnings";
 @import "settings/prefixer";
 @import "settings/px-to-em";
 @import "settings/asset-pipeline";
+
+@import "bourbon-deprecate";
 
 @import "functions/assign-inputs";
 @import "functions/contains";

--- a/app/assets/stylesheets/addons/_retina-image.scss
+++ b/app/assets/stylesheets/addons/_retina-image.scss
@@ -1,4 +1,6 @@
 @mixin retina-image($filename, $background-size, $extension: png, $retina-filename: null, $retina-suffix: _2x, $asset-pipeline: $asset-pipeline) {
+  @include _bourbon-deprecate("retina-image");
+
   @if $asset-pipeline {
     background-image: image-url("#{$filename}.#{$extension}");
   } @else {

--- a/app/assets/stylesheets/css3/_animation.scss
+++ b/app/assets/stylesheets/css3/_animation.scss
@@ -2,42 +2,60 @@
 // Each of these mixins support comma separated lists of values, which allows different transitions for individual properties to be described in a single style rule. Each value in the list corresponds to the value at that same position in the other properties.
 
 @mixin animation($animations...) {
+  @include _bourbon-deprecate-for-prefixing("animation");
+
   @include prefixer(animation, $animations, webkit moz spec);
 }
 
 @mixin animation-name($names...) {
+  @include _bourbon-deprecate-for-prefixing("animation-name");
+
   @include prefixer(animation-name, $names, webkit moz spec);
 }
 
 @mixin animation-duration($times...) {
+  @include _bourbon-deprecate-for-prefixing("animation-duration");
+
   @include prefixer(animation-duration, $times, webkit moz spec);
 }
 
 @mixin animation-timing-function($motions...) {
+  @include _bourbon-deprecate-for-prefixing("animation-timing-function");
+
   // ease | linear | ease-in | ease-out | ease-in-out
   @include prefixer(animation-timing-function, $motions, webkit moz spec);
 }
 
 @mixin animation-iteration-count($values...) {
+  @include _bourbon-deprecate-for-prefixing("animation-iteration-count");
+
   // infinite | <number>
   @include prefixer(animation-iteration-count, $values, webkit moz spec);
 }
 
 @mixin animation-direction($directions...) {
+  @include _bourbon-deprecate-for-prefixing("animation-direction");
+
   // normal | alternate
   @include prefixer(animation-direction, $directions, webkit moz spec);
 }
 
 @mixin animation-play-state($states...) {
+  @include _bourbon-deprecate-for-prefixing("animation-play-state");
+
   // running | paused
   @include prefixer(animation-play-state, $states, webkit moz spec);
 }
 
 @mixin animation-delay($times...) {
+  @include _bourbon-deprecate-for-prefixing("animation-delay");
+
   @include prefixer(animation-delay, $times, webkit moz spec);
 }
 
 @mixin animation-fill-mode($modes...) {
+  @include _bourbon-deprecate-for-prefixing("animation-fill-mode");
+
   // none | forwards | backwards | both
   @include prefixer(animation-fill-mode, $modes, webkit moz spec);
 }

--- a/app/assets/stylesheets/css3/_appearance.scss
+++ b/app/assets/stylesheets/css3/_appearance.scss
@@ -1,3 +1,5 @@
 @mixin appearance($value) {
+  @include _bourbon-deprecate-for-prefixing("appearance");
+
   @include prefixer(appearance, $value, webkit moz ms o spec);
 }

--- a/app/assets/stylesheets/css3/_backface-visibility.scss
+++ b/app/assets/stylesheets/css3/_backface-visibility.scss
@@ -1,3 +1,5 @@
 @mixin backface-visibility($visibility) {
+  @include _bourbon-deprecate-for-prefixing("backface-visibility");
+
   @include prefixer(backface-visibility, $visibility, webkit spec);
 }

--- a/app/assets/stylesheets/css3/_background-image.scss
+++ b/app/assets/stylesheets/css3/_background-image.scss
@@ -4,6 +4,8 @@
 //************************************************************************//
 
 @mixin background-image($images...) {
+  @include _bourbon-deprecate-for-prefixing("background-image");
+
   $webkit-images: ();
   $spec-images: ();
 

--- a/app/assets/stylesheets/css3/_background.scss
+++ b/app/assets/stylesheets/css3/_background.scss
@@ -4,6 +4,8 @@
 //************************************************************************//
 
 @mixin background($backgrounds...) {
+  @include _bourbon-deprecate-for-prefixing("background");
+
   $webkit-backgrounds: ();
   $spec-backgrounds: ();
 

--- a/app/assets/stylesheets/css3/_border-image.scss
+++ b/app/assets/stylesheets/css3/_border-image.scss
@@ -1,4 +1,6 @@
 @mixin border-image($borders...) {
+  @include _bourbon-deprecate-for-prefixing("border-image");
+
   $webkit-borders: ();
   $spec-borders: ();
 

--- a/app/assets/stylesheets/css3/_calc.scss
+++ b/app/assets/stylesheets/css3/_calc.scss
@@ -1,4 +1,6 @@
 @mixin calc($property, $value) {
+  @include _bourbon-deprecate-for-prefixing("calc");
+
   #{$property}: -webkit-calc(#{$value});
   #{$property}: calc(#{$value});
 }

--- a/app/assets/stylesheets/css3/_columns.scss
+++ b/app/assets/stylesheets/css3/_columns.scss
@@ -1,47 +1,67 @@
 @mixin columns($arg: auto) {
+  @include _bourbon-deprecate-for-prefixing("columns");
+
   // <column-count> || <column-width>
   @include prefixer(columns, $arg, webkit moz spec);
 }
 
 @mixin column-count($int: auto) {
+  @include _bourbon-deprecate-for-prefixing("column-count");
+
   // auto || integer
   @include prefixer(column-count, $int, webkit moz spec);
 }
 
 @mixin column-gap($length: normal) {
+  @include _bourbon-deprecate-for-prefixing("column-gap");
+
   // normal || length
   @include prefixer(column-gap, $length, webkit moz spec);
 }
 
 @mixin column-fill($arg: auto) {
+  @include _bourbon-deprecate-for-prefixing("column-fill");
+
   // auto || length
   @include prefixer(column-fill, $arg, webkit moz spec);
 }
 
 @mixin column-rule($arg) {
+  @include _bourbon-deprecate-for-prefixing("column-rule");
+
   // <border-width> || <border-style> || <color>
   @include prefixer(column-rule, $arg, webkit moz spec);
 }
 
 @mixin column-rule-color($color) {
+  @include _bourbon-deprecate-for-prefixing("column-rule-color");
+
   @include prefixer(column-rule-color, $color, webkit moz spec);
 }
 
 @mixin column-rule-style($style: none) {
+  @include _bourbon-deprecate-for-prefixing("column-rule-style");
+
   // none | hidden | dashed | dotted | double | groove | inset | inset | outset | ridge | solid
   @include prefixer(column-rule-style, $style, webkit moz spec);
 }
 
-@mixin column-rule-width ($width: none) {
+@mixin column-rule-width($width: none) {
+  @include _bourbon-deprecate-for-prefixing("column-rule-width");
+
   @include prefixer(column-rule-width, $width, webkit moz spec);
 }
 
 @mixin column-span($arg: none) {
+  @include _bourbon-deprecate-for-prefixing("column-span");
+
   // none || all
   @include prefixer(column-span, $arg, webkit moz spec);
 }
 
 @mixin column-width($length: auto) {
+  @include _bourbon-deprecate-for-prefixing("column-width");
+
   // auto || length
   @include prefixer(column-width, $length, webkit moz spec);
 }

--- a/app/assets/stylesheets/css3/_filter.scss
+++ b/app/assets/stylesheets/css3/_filter.scss
@@ -1,4 +1,6 @@
 @mixin filter($function: none) {
+  @include _bourbon-deprecate-for-prefixing("filter");
+
   // <filter-function> [<filter-function]* | none
   @include prefixer(filter, $function, webkit spec);
 }

--- a/app/assets/stylesheets/css3/_flex-box.scss
+++ b/app/assets/stylesheets/css3/_flex-box.scss
@@ -2,6 +2,8 @@
 
 // Custom shorthand notation for flexbox
 @mixin box($orient: inline-axis, $pack: start, $align: stretch) {
+  @include _bourbon-deprecate-for-prefixing("box");
+
   @include display-box;
   @include box-orient($orient);
   @include box-pack($pack);
@@ -9,6 +11,8 @@
 }
 
 @mixin display-box {
+  @include _bourbon-deprecate-for-prefixing("display-box");
+
   display: -webkit-box;
   display: -moz-box;
   display: -ms-flexbox; // IE 10
@@ -16,44 +20,60 @@
 }
 
 @mixin box-orient($orient: inline-axis) {
+  @include _bourbon-deprecate-for-prefixing("box-orient");
+
 // horizontal|vertical|inline-axis|block-axis|inherit
   @include prefixer(box-orient, $orient, webkit moz spec);
 }
 
 @mixin box-pack($pack: start) {
+  @include _bourbon-deprecate-for-prefixing("box-pack");
+
 // start|end|center|justify
   @include prefixer(box-pack, $pack, webkit moz spec);
   -ms-flex-pack: $pack; // IE 10
 }
 
 @mixin box-align($align: stretch) {
+  @include _bourbon-deprecate-for-prefixing("box-align");
+
 // start|end|center|baseline|stretch
   @include prefixer(box-align, $align, webkit moz spec);
   -ms-flex-align: $align; // IE 10
 }
 
 @mixin box-direction($direction: normal) {
+  @include _bourbon-deprecate-for-prefixing("box-direction");
+
 // normal|reverse|inherit
   @include prefixer(box-direction, $direction, webkit moz spec);
   -ms-flex-direction: $direction; // IE 10
 }
 
 @mixin box-lines($lines: single) {
+  @include _bourbon-deprecate-for-prefixing("box-lines");
+
 // single|multiple
   @include prefixer(box-lines, $lines, webkit moz spec);
 }
 
 @mixin box-ordinal-group($int: 1) {
+  @include _bourbon-deprecate-for-prefixing("box-ordinal-group");
+
   @include prefixer(box-ordinal-group, $int, webkit moz spec);
   -ms-flex-order: $int; // IE 10
 }
 
 @mixin box-flex($value: 0) {
+  @include _bourbon-deprecate-for-prefixing("box-flex");
+
   @include prefixer(box-flex, $value, webkit moz spec);
   -ms-flex: $value; // IE 10
 }
 
 @mixin box-flex-group($int: 1) {
+  @include _bourbon-deprecate-for-prefixing("box-flex-group");
+
   @include prefixer(box-flex-group, $int, webkit moz spec);
 }
 
@@ -64,6 +84,8 @@
 // 2011 - display (flexbox | inline-flexbox)
 // 2012 - display (flex | inline-flex)
 @mixin display($value) {
+  @include _bourbon-deprecate-for-prefixing("display");
+
 // flex | inline-flex
   @if $value == "flex" {
     // 2009
@@ -94,6 +116,7 @@
 // 2011 - flex (decimal | width decimal)
 // 2012 - flex (integer integer width)
 @mixin flex($value) {
+  @include _bourbon-deprecate-for-prefixing("flex");
 
   // Grab flex-grow for older browsers.
   $flex-grow: nth($value, 1);
@@ -110,6 +133,7 @@
 // 2011 - flex-direction (row | row-reverse | column | column-reverse)
 // 2012 - flex-direction (row | row-reverse | column | column-reverse)
 @mixin flex-direction($value: row) {
+  @include _bourbon-deprecate-for-prefixing("flex-direction");
 
   // Alt values.
   $value-2009: $value;
@@ -143,6 +167,8 @@
 // 2011 - flex-wrap (nowrap | wrap | wrap-reverse)
 // 2012 - flex-wrap (nowrap | wrap | wrap-reverse)
 @mixin flex-wrap($value: nowrap) {
+  @include _bourbon-deprecate-for-prefixing("flex-wrap");
+
   // Alt values
   $alt-value: $value;
   @if $value == nowrap {
@@ -161,6 +187,8 @@
 // 2011 - TODO: parse values into flex-direction/flex-wrap
 // 2012 - flex-flow (flex-direction || flex-wrap)
 @mixin flex-flow($value) {
+  @include _bourbon-deprecate-for-prefixing("flex-flow");
+
   @include prefixer(flex-flow, $value, webkit moz spec);
 }
 
@@ -168,6 +196,8 @@
 // 2011 - flex-order (integer)
 // 2012 - order (integer)
 @mixin order($int: 0) {
+  @include _bourbon-deprecate-for-prefixing("order");
+
   // 2009
   @include prefixer(box-ordinal-group, $int, webkit moz spec);
 
@@ -180,18 +210,24 @@
 
 // 2012 - flex-grow (number)
 @mixin flex-grow($number: 0) {
+  @include _bourbon-deprecate-for-prefixing("flex-grow");
+
   @include prefixer(flex-grow, $number, webkit moz spec);
   -ms-flex-positive: $number;
 }
 
 // 2012 - flex-shrink (number)
 @mixin flex-shrink($number: 1) {
+  @include _bourbon-deprecate-for-prefixing("flex-shrink");
+
   @include prefixer(flex-shrink, $number, webkit moz spec);
   -ms-flex-negative: $number;
 }
 
 // 2012 - flex-basis (number)
 @mixin flex-basis($width: auto) {
+  @include _bourbon-deprecate-for-prefixing("flex-basis");
+
   @include prefixer(flex-basis, $width, webkit moz spec);
   -ms-flex-preferred-size: $width;
 }
@@ -200,6 +236,7 @@
 // 2011 - flex-pack (start | end | center | justify)
 // 2012 - justify-content (flex-start | flex-end | center | space-between | space-around)
 @mixin justify-content($value: flex-start) {
+  @include _bourbon-deprecate-for-prefixing("justify-content");
 
   // Alt values.
   $alt-value: $value;
@@ -227,6 +264,7 @@
 // 2011 - flex-align (start | end | center | baseline | stretch)
 // 2012 - align-items (flex-start | flex-end | center | baseline | stretch)
 @mixin align-items($value: stretch) {
+  @include _bourbon-deprecate-for-prefixing("align-items");
 
   $alt-value: $value;
 
@@ -249,6 +287,7 @@
 // 2011 - flex-item-align (auto | start | end | center | baseline | stretch)
 // 2012 - align-self (auto | flex-start | flex-end | center | baseline | stretch)
 @mixin align-self($value: auto) {
+  @include _bourbon-deprecate-for-prefixing("align-self");
 
   $value-2011: $value;
   @if $value == "flex-start" {
@@ -267,6 +306,7 @@
 // 2011 - flex-line-pack (start | end | center | justify | distribute | stretch)
 // 2012 - align-content (flex-start | flex-end | center | space-between | space-around | stretch)
 @mixin align-content($value: stretch) {
+  @include _bourbon-deprecate-for-prefixing("align-content");
 
   $value-2011: $value;
   @if $value == "flex-start" {

--- a/app/assets/stylesheets/css3/_font-feature-settings.scss
+++ b/app/assets/stylesheets/css3/_font-feature-settings.scss
@@ -1,4 +1,6 @@
 @mixin font-feature-settings($settings...) {
+  @include _bourbon-deprecate-for-prefixing("font-feature-settings");
+
   @if length($settings) == 0 { $settings: none; }
   @include prefixer(font-feature-settings, $settings, webkit moz ms spec);
 }

--- a/app/assets/stylesheets/css3/_hidpi-media-query.scss
+++ b/app/assets/stylesheets/css3/_hidpi-media-query.scss
@@ -1,5 +1,7 @@
 // HiDPI mixin. Default value set to 1.3 to target Google Nexus 7 (http://bjango.com/articles/min-device-pixel-ratio/)
 @mixin hidpi($ratio: 1.3) {
+  @include _bourbon-deprecate-for-prefixing("hidpi");
+
   @media only screen and (-webkit-min-device-pixel-ratio: $ratio),
   only screen and (min--moz-device-pixel-ratio: $ratio),
   only screen and (-o-min-device-pixel-ratio: #{$ratio}/1),

--- a/app/assets/stylesheets/css3/_hyphens.scss
+++ b/app/assets/stylesheets/css3/_hyphens.scss
@@ -1,4 +1,6 @@
 @mixin hyphens($hyphenation: none) {
+  @include _bourbon-deprecate-for-prefixing("hyphens");
+
   // none | manual | auto
   @include prefixer(hyphens, $hyphenation, webkit moz ms spec);
 }

--- a/app/assets/stylesheets/css3/_image-rendering.scss
+++ b/app/assets/stylesheets/css3/_image-rendering.scss
@@ -1,4 +1,5 @@
 @mixin image-rendering ($mode:auto) {
+  @include _bourbon-deprecate-for-prefixing("image-rendering");
 
   @if ($mode == crisp-edges) {
     -ms-interpolation-mode: nearest-neighbor; // IE8+

--- a/app/assets/stylesheets/css3/_keyframes.scss
+++ b/app/assets/stylesheets/css3/_keyframes.scss
@@ -1,5 +1,7 @@
 // Adds keyframes blocks for supported prefixes, removing redundant prefixes in the block's content
 @mixin keyframes($name) {
+  @include _bourbon-deprecate-for-prefixing("keyframes");
+
   $original-prefix-for-webkit:    $prefix-for-webkit;
   $original-prefix-for-mozilla:   $prefix-for-mozilla;
   $original-prefix-for-microsoft: $prefix-for-microsoft;

--- a/app/assets/stylesheets/css3/_linear-gradient.scss
+++ b/app/assets/stylesheets/css3/_linear-gradient.scss
@@ -4,6 +4,8 @@
                        $g7: null, $g8: null,
                        $g9: null, $g10: null,
                        $fallback: null) {
+  @include _bourbon-deprecate-for-prefixing("linear-gradient");
+
   // Detect what type of value exists in $pos
   $pos-type: type-of(nth($pos, 1));
   $pos-spec: null;

--- a/app/assets/stylesheets/css3/_perspective.scss
+++ b/app/assets/stylesheets/css3/_perspective.scss
@@ -1,8 +1,12 @@
 @mixin perspective($depth: none) {
+  @include _bourbon-deprecate-for-prefixing("perspective");
+
   // none | <length>
   @include prefixer(perspective, $depth, webkit moz spec);
 }
 
 @mixin perspective-origin($value: 50% 50%) {
+  @include _bourbon-deprecate-for-prefixing("perspective-origin");
+
   @include prefixer(perspective-origin, $value, webkit moz spec);
 }

--- a/app/assets/stylesheets/css3/_placeholder.scss
+++ b/app/assets/stylesheets/css3/_placeholder.scss
@@ -1,4 +1,6 @@
 @mixin placeholder {
+  @include _bourbon-deprecate-for-prefixing("placeholder");
+
   $placeholders: ":-webkit-input" ":-moz" "-moz" "-ms-input";
   @each $placeholder in $placeholders {
     &:#{$placeholder}-placeholder {

--- a/app/assets/stylesheets/css3/_radial-gradient.scss
+++ b/app/assets/stylesheets/css3/_radial-gradient.scss
@@ -7,6 +7,7 @@
                        $pos: null,
                        $shape-size: null,
                        $fallback: null) {
+  @include _bourbon-deprecate-for-prefixing("radial-gradient");
 
   $data: _radial-arg-parser($g1, $g2, $pos, $shape-size);
   $g1:  nth($data, 1);

--- a/app/assets/stylesheets/css3/_selection.scss
+++ b/app/assets/stylesheets/css3/_selection.scss
@@ -22,6 +22,8 @@
 ///   }
 
 @mixin selection($current-selector: false) {
+  @include _bourbon-deprecate-for-prefixing("selection");
+
   @if $current-selector {
     &::-moz-selection {
       @content;

--- a/app/assets/stylesheets/css3/_text-decoration.scss
+++ b/app/assets/stylesheets/css3/_text-decoration.scss
@@ -1,19 +1,27 @@
 @mixin text-decoration($value) {
+  @include _bourbon-deprecate-for-prefixing("text-decoration");
+
 // <text-decoration-line> || <text-decoration-style> || <text-decoration-color>
   @include prefixer(text-decoration, $value, moz);
 }
 
 @mixin text-decoration-line($line: none) {
+  @include _bourbon-deprecate-for-prefixing("text-decoration-line");
+
 // none || underline || overline || line-through
   @include prefixer(text-decoration-line, $line, moz);
 }
 
 @mixin text-decoration-style($style: solid) {
+  @include _bourbon-deprecate-for-prefixing("text-decoration-style");
+
 // solid || double || dotted || dashed || wavy
   @include prefixer(text-decoration-style, $style, moz webkit);
 }
 
 @mixin text-decoration-color($color: currentColor) {
+  @include _bourbon-deprecate-for-prefixing("text-decoration-color");
+
 // currentColor || <color>
   @include prefixer(text-decoration-color, $color, moz);
 }

--- a/app/assets/stylesheets/css3/_transform.scss
+++ b/app/assets/stylesheets/css3/_transform.scss
@@ -1,9 +1,13 @@
 @mixin transform($property: none) {
+  @include _bourbon-deprecate-for-prefixing("transform");
+
   // none | <transform-function>
   @include prefixer(transform, $property, webkit moz ms o spec);
 }
 
 @mixin transform-origin($axes: 50%) {
+  @include _bourbon-deprecate-for-prefixing("transform-origin");
+
   // x-axis - left | center | right  | length | %
   // y-axis - top  | center | bottom | length | %
   // z-axis -                          length
@@ -11,5 +15,7 @@
 }
 
 @mixin transform-style($style: flat) {
+  @include _bourbon-deprecate-for-prefixing("transform-style");
+
   @include prefixer(transform-style, $style, webkit moz ms o spec);
 }

--- a/app/assets/stylesheets/css3/_transition.scss
+++ b/app/assets/stylesheets/css3/_transition.scss
@@ -4,6 +4,8 @@
 //          @include transition-property (transform, opacity);
 
 @mixin transition($properties...) {
+  @include _bourbon-deprecate-for-prefixing("transition");
+
   // Fix for vendor-prefix transform property
   $needs-prefixes: false;
   $webkit: ();
@@ -52,20 +54,28 @@
 }
 
 @mixin transition-property($properties...) {
+  @include _bourbon-deprecate-for-prefixing("transition-property");
+
   -webkit-transition-property: transition-property-names($properties, "webkit");
      -moz-transition-property: transition-property-names($properties, "moz");
           transition-property: transition-property-names($properties, false);
 }
 
 @mixin transition-duration($times...) {
+  @include _bourbon-deprecate-for-prefixing("transition-duration");
+
   @include prefixer(transition-duration, $times, webkit moz spec);
 }
 
 @mixin transition-timing-function($motions...) {
+  @include _bourbon-deprecate-for-prefixing("transition-timing-function");
+
   // ease | linear | ease-in | ease-out | ease-in-out | cubic-bezier()
   @include prefixer(transition-timing-function, $motions, webkit moz spec);
 }
 
 @mixin transition-delay($times...) {
+  @include _bourbon-deprecate-for-prefixing("transition-delay");
+
   @include prefixer(transition-delay, $times, webkit moz spec);
 }

--- a/app/assets/stylesheets/css3/_user-select.scss
+++ b/app/assets/stylesheets/css3/_user-select.scss
@@ -1,3 +1,5 @@
 @mixin user-select($value: none) {
+  @include _bourbon-deprecate-for-prefixing("user-select");
+
   @include prefixer(user-select, $value, webkit moz ms spec);
 }

--- a/app/assets/stylesheets/functions/_assign-inputs.scss
+++ b/app/assets/stylesheets/functions/_assign-inputs.scss
@@ -1,4 +1,9 @@
 @function assign-inputs($inputs, $pseudo: null) {
+  @if $output-bourbon-deprecation-warnings == true {
+    @warn "[Bourbon] [Deprecation] `assign-inputs` is deprecated and will be " +
+    "removed in 5.0.0.";
+  }
+
   $list: ();
 
   @each $input in $inputs {

--- a/app/assets/stylesheets/functions/_contains-falsy.scss
+++ b/app/assets/stylesheets/functions/_contains-falsy.scss
@@ -10,6 +10,11 @@
 /// @return {Bool}
 
 @function contains-falsy($list) {
+  @if $output-bourbon-deprecation-warnings == true {
+    @warn "[Bourbon] [Deprecation] `contains-falsy` is deprecated and will be " +
+    "removed in 5.0.0.";
+  }
+
   @each $item in $list {
     @if not $item {
       @return true;

--- a/app/assets/stylesheets/functions/_contains.scss
+++ b/app/assets/stylesheets/functions/_contains.scss
@@ -16,6 +16,11 @@
 /// @return {Bool}
 
 @function contains($list, $values...) {
+  @if $output-bourbon-deprecation-warnings == true {
+    @warn "[Bourbon] [Deprecation] `contains` is deprecated and will be " +
+    "removed in 5.0.0.";
+  }
+
   @each $value in $values {
     @if type-of(index($list, $value)) != "number" {
       @return false;

--- a/app/assets/stylesheets/functions/_is-length.scss
+++ b/app/assets/stylesheets/functions/_is-length.scss
@@ -5,6 +5,11 @@
 /// @param {String} $value
 
 @function is-length($value) {
+  @if $output-bourbon-deprecation-warnings == true {
+    @warn "[Bourbon] [Deprecation] `is-length` is deprecated and will be " +
+    "removed in 5.0.0.";
+  }
+
   @return type-of($value) != "null" and (str-slice($value + "", 1, 4) == "calc"
        or index(auto inherit initial 0, $value)
        or (type-of($value) == "number" and not(unitless($value))));

--- a/app/assets/stylesheets/functions/_is-light.scss
+++ b/app/assets/stylesheets/functions/_is-light.scss
@@ -12,6 +12,11 @@
 /// @return {Bool}
 
 @function is-light($hex-color) {
+  @if $output-bourbon-deprecation-warnings == true {
+    @warn "[Bourbon] [Deprecation] `is-light` is deprecated and will be " +
+    "removed in 5.0.0.";
+  }
+
   $-local-red: red(rgba($hex-color, 1));
   $-local-green: green(rgba($hex-color, 1));
   $-local-blue: blue(rgba($hex-color, 1));

--- a/app/assets/stylesheets/functions/_is-number.scss
+++ b/app/assets/stylesheets/functions/_is-number.scss
@@ -7,5 +7,10 @@
 /// @require {function} contains
 
 @function is-number($value) {
+  @if $output-bourbon-deprecation-warnings == true {
+    @warn "[Bourbon] [Deprecation] `is-number` is deprecated and will be " +
+    "removed in 5.0.0.";
+  }
+
   @return contains("0" "1" "2" "3" "4" "5" "6" "7" "8" "9" 0 1 2 3 4 5 6 7 8 9, $value);
 }

--- a/app/assets/stylesheets/functions/_is-size.scss
+++ b/app/assets/stylesheets/functions/_is-size.scss
@@ -8,6 +8,11 @@
 /// @require {function} is-length
 
 @function is-size($value) {
+  @if $output-bourbon-deprecation-warnings == true {
+    @warn "[Bourbon] [Deprecation] `is-size` is deprecated and will be " +
+    "removed in 5.0.0.";
+  }
+
   @return is-length($value)
           or contains("fill" "fit-content" "min-content" "max-content", $value);
 }

--- a/app/assets/stylesheets/functions/_px-to-em.scss
+++ b/app/assets/stylesheets/functions/_px-to-em.scss
@@ -3,6 +3,11 @@
 // if the parent is another value say 24px write em(12, 24)
 
 @function em($pxval, $base: $em-base) {
+  @if $output-bourbon-deprecation-warnings == true {
+    @warn "[Bourbon] [Deprecation] `em` is deprecated and will be " +
+    "removed in 5.0.0.";
+  }
+
   @if not unitless($pxval) {
     $pxval: strip-units($pxval);
   }

--- a/app/assets/stylesheets/functions/_px-to-rem.scss
+++ b/app/assets/stylesheets/functions/_px-to-rem.scss
@@ -3,6 +3,11 @@
 // Assumes $em-base is the font-size of <html>
 
 @function rem($pxval) {
+  @if $output-bourbon-deprecation-warnings == true {
+    @warn "[Bourbon] [Deprecation] `rem` is deprecated and will be " +
+    "removed in 5.0.0.";
+  }
+
   @if not unitless($pxval) {
     $pxval: strip-units($pxval);
   }

--- a/app/assets/stylesheets/functions/_strip-units.scss
+++ b/app/assets/stylesheets/functions/_strip-units.scss
@@ -13,5 +13,10 @@
 /// @return {Number (Unitless)}
 
 @function strip-units($value) {
+  @if $output-bourbon-deprecation-warnings == true {
+    @warn "[Bourbon] [Deprecation] `strip-units` is deprecated and will be " +
+    "removed in 5.0.0. Use the renamed `strip-unit` function instead.";
+  }
+
   @return ($value / ($value * 0 + 1));
 }

--- a/app/assets/stylesheets/functions/_transition-property-name.scss
+++ b/app/assets/stylesheets/functions/_transition-property-name.scss
@@ -2,6 +2,11 @@
 // Example: transition-property-names((transform, color, background), moz) -> -moz-transform, color, background
 //************************************************************************//
 @function transition-property-names($props, $vendor: false) {
+  @if $output-bourbon-deprecation-warnings == true {
+    @warn "[Bourbon] [Deprecation] `transition-property-names` is deprecated " +
+    "and will be removed in 5.0.0.";
+  }
+
   $new-props: ();
 
   @each $prop in $props {
@@ -12,6 +17,11 @@
 }
 
 @function transition-property-name($prop, $vendor: false) {
+  @if $output-bourbon-deprecation-warnings == true {
+    @warn "[Bourbon] [Deprecation] `transition-property-name` is deprecated " +
+    "and will be removed in 5.0.0.";
+  }
+
   // put other properties that need to be prefixed here aswell
   @if $vendor and $prop == transform {
     @return unquote('-'+$vendor+'-'+$prop);

--- a/app/assets/stylesheets/functions/_unpack.scss
+++ b/app/assets/stylesheets/functions/_unpack.scss
@@ -15,6 +15,11 @@
 ///   }
 
 @function unpack($shorthand) {
+  @if $output-bourbon-deprecation-warnings == true {
+    @warn "[Bourbon] [Deprecation] `unpack` is deprecated and will be " +
+    "removed in 5.0.0.";
+  }
+
   @if length($shorthand) == 1 {
     @return nth($shorthand, 1) nth($shorthand, 1) nth($shorthand, 1) nth($shorthand, 1);
   } @else if length($shorthand) == 2 {

--- a/app/assets/stylesheets/helpers/_convert-units.scss
+++ b/app/assets/stylesheets/helpers/_convert-units.scss
@@ -3,6 +3,11 @@
 // Source: http://sassmeister.com/gist/9647408
 //************************************************************************//
 @function _convert-units($number, $unit) {
+  @if $output-bourbon-deprecation-warnings == true {
+    @warn "[Bourbon] [Deprecation] `_convert-units` is deprecated and will " +
+    "be removed in 5.0.0.";
+  }
+
   $strings: "px", "cm", "mm", "%", "ch", "pica", "in", "em", "rem", "pt", "pc", "ex", "vw", "vh", "vmin", "vmax", "deg", "rad", "grad", "turn";
   $units:   1px, 1cm, 1mm, 1%, 1ch, 1pica, 1in, 1em, 1rem, 1pt, 1pc, 1ex, 1vw, 1vh, 1vmin, 1vmax, 1deg, 1rad, 1grad, 1turn;
   $index: index($strings, $unit);

--- a/app/assets/stylesheets/helpers/_directional-values.scss
+++ b/app/assets/stylesheets/helpers/_directional-values.scss
@@ -27,6 +27,11 @@
 /// @return {List}
 
 @function collapse-directionals($vals) {
+  @if $output-bourbon-deprecation-warnings == true {
+    @warn "[Bourbon] [Deprecation] `collapse-directionals` is deprecated and " +
+    "will be removed in 5.0.0.";
+  }
+
   $output: null;
 
   $a: nth($vals, 1);
@@ -62,6 +67,8 @@
 /// @require {function} contains-falsy
 
 @mixin directional-property($pre, $suf, $vals) {
+  @include _bourbon-deprecate("directional-property");
+
   // Property Names
   $top:    $pre + "-top"    + if($suf, "-#{$suf}", "");
   $bottom: $pre + "-bottom" + if($suf, "-#{$suf}", "");

--- a/app/assets/stylesheets/helpers/_font-source-declaration.scss
+++ b/app/assets/stylesheets/helpers/_font-source-declaration.scss
@@ -2,6 +2,11 @@
 // Reference: http://goo.gl/Ru1bKP
 
 @function font-url-prefixer($asset-pipeline) {
+  @if $output-bourbon-deprecation-warnings == true {
+    @warn "[Bourbon] [Deprecation] `font-url-prefixer` is deprecated and " +
+    "will be removed in 5.0.0.";
+  }
+
   @if $asset-pipeline == true {
     @return font-url;
   } @else {
@@ -15,6 +20,11 @@
   $asset-pipeline,
   $file-formats,
   $font-url) {
+
+  @if $output-bourbon-deprecation-warnings == true {
+    @warn "[Bourbon] [Deprecation] `font-source-declaration` is deprecated " +
+    "and will be removed in 5.0.0.";
+  }
 
   $src: ();
 

--- a/app/assets/stylesheets/helpers/_gradient-positions-parser.scss
+++ b/app/assets/stylesheets/helpers/_gradient-positions-parser.scss
@@ -1,4 +1,9 @@
 @function _gradient-positions-parser($gradient-type, $gradient-positions) {
+  @if $output-bourbon-deprecation-warnings == true {
+    @warn "[Bourbon] [Deprecation] `_gradient-positions-parser` is " +
+    "deprecated and will be removed in 5.0.0.";
+  }
+
   @if $gradient-positions
   and ($gradient-type == linear)
   and (type-of($gradient-positions) != color) {

--- a/app/assets/stylesheets/helpers/_linear-angle-parser.scss
+++ b/app/assets/stylesheets/helpers/_linear-angle-parser.scss
@@ -1,5 +1,10 @@
 // Private function for linear-gradient-parser
 @function _linear-angle-parser($image, $first-val, $prefix, $suffix) {
+  @if $output-bourbon-deprecation-warnings == true {
+    @warn "[Bourbon] [Deprecation] `_linear-angle-parser` is " +
+    "deprecated and will be removed in 5.0.0.";
+  }
+
   $offset: null;
   $unit-short:  str-slice($first-val, str-length($first-val) - 2, str-length($first-val));
   $unit-long:   str-slice($first-val, str-length($first-val) - 3, str-length($first-val));

--- a/app/assets/stylesheets/helpers/_linear-gradient-parser.scss
+++ b/app/assets/stylesheets/helpers/_linear-gradient-parser.scss
@@ -1,4 +1,9 @@
 @function _linear-gradient-parser($image) {
+  @if $output-bourbon-deprecation-warnings == true {
+    @warn "[Bourbon] [Deprecation] `_linear-gradient-parser` is " +
+    "deprecated and will be removed in 5.0.0.";
+  }
+
   $image: unquote($image);
   $gradients: ();
   $start: str-index($image, "(");

--- a/app/assets/stylesheets/helpers/_linear-positions-parser.scss
+++ b/app/assets/stylesheets/helpers/_linear-positions-parser.scss
@@ -1,4 +1,9 @@
 @function _linear-positions-parser($pos) {
+  @if $output-bourbon-deprecation-warnings == true {
+    @warn "[Bourbon] [Deprecation] `_linear-positions-parser` is " +
+    "deprecated and will be removed in 5.0.0.";
+  }
+
   $type: type-of(nth($pos, 1));
   $spec: null;
   $degree: null;
@@ -54,6 +59,11 @@
 }
 
 @function _position-flipper($pos) {
+  @if $output-bourbon-deprecation-warnings == true {
+    @warn "[Bourbon] [Deprecation] `_position-flipper` is " +
+    "deprecated and will be removed in 5.0.0.";
+  }
+
   @return if($pos == left, right, null)
          if($pos == right, left, null)
          if($pos == top, bottom, null)

--- a/app/assets/stylesheets/helpers/_linear-side-corner-parser.scss
+++ b/app/assets/stylesheets/helpers/_linear-side-corner-parser.scss
@@ -1,5 +1,10 @@
 // Private function for linear-gradient-parser
 @function _linear-side-corner-parser($image, $first-val, $prefix, $suffix, $has-multiple-vals) {
+  @if $output-bourbon-deprecation-warnings == true {
+    @warn "[Bourbon] [Deprecation] `_linear-side-corner-parser` is " +
+    "deprecated and will be removed in 5.0.0.";
+  }
+
   $val-1: str-slice($first-val, 1, $has-multiple-vals - 1);
   $val-2: str-slice($first-val, $has-multiple-vals + 1, str-length($first-val));
   $val-3: null;

--- a/app/assets/stylesheets/helpers/_radial-arg-parser.scss
+++ b/app/assets/stylesheets/helpers/_radial-arg-parser.scss
@@ -1,4 +1,9 @@
 @function _radial-arg-parser($g1, $g2, $pos, $shape-size) {
+  @if $output-bourbon-deprecation-warnings == true {
+    @warn "[Bourbon] [Deprecation] `_radial-arg-parser` is " +
+    "deprecated and will be removed in 5.0.0.";
+  }
+
   @each $value in $g1, $g2 {
     $first-val: nth($value, 1);
     $pos-type:  type-of($first-val);

--- a/app/assets/stylesheets/helpers/_radial-gradient-parser.scss
+++ b/app/assets/stylesheets/helpers/_radial-gradient-parser.scss
@@ -1,4 +1,9 @@
 @function _radial-gradient-parser($image) {
+  @if $output-bourbon-deprecation-warnings == true {
+    @warn "[Bourbon] [Deprecation] `_radial-gradient-parser` is " +
+    "deprecated and will be removed in 5.0.0.";
+  }
+
   $image: unquote($image);
   $gradients: ();
   $start: str-index($image, "(");

--- a/app/assets/stylesheets/helpers/_radial-positions-parser.scss
+++ b/app/assets/stylesheets/helpers/_radial-positions-parser.scss
@@ -1,4 +1,9 @@
 @function _radial-positions-parser($gradient-pos) {
+  @if $output-bourbon-deprecation-warnings == true {
+    @warn "[Bourbon] [Deprecation] `_radial-positions-parser` is " +
+    "deprecated and will be removed in 5.0.0.";
+  }
+
   $shape-size: nth($gradient-pos, 1);
   $pos:        nth($gradient-pos, 2);
   $shape-size-spec: _shape-size-stripper($shape-size);

--- a/app/assets/stylesheets/helpers/_render-gradients.scss
+++ b/app/assets/stylesheets/helpers/_render-gradients.scss
@@ -1,6 +1,11 @@
 // User for linear and radial gradients within background-image or border-image properties
 
 @function _render-gradients($gradient-positions, $gradients, $gradient-type, $vendor: false) {
+  @if $output-bourbon-deprecation-warnings == true {
+    @warn "[Bourbon] [Deprecation] `_render-gradients` is " +
+    "deprecated and will be removed in 5.0.0.";
+  }
+
   $pre-spec: null;
   $spec: null;
   $vendor-gradients: null;

--- a/app/assets/stylesheets/helpers/_shape-size-stripper.scss
+++ b/app/assets/stylesheets/helpers/_shape-size-stripper.scss
@@ -1,4 +1,9 @@
 @function _shape-size-stripper($shape-size) {
+  @if $output-bourbon-deprecation-warnings == true {
+    @warn "[Bourbon] [Deprecation] `_shape-size-stripper` is " +
+    "deprecated and will be removed in 5.0.0.";
+  }
+
   $shape-size-spec: null;
   @each $value in $shape-size {
     @if ($value == "cover") or ($value == "contain") {

--- a/app/assets/stylesheets/helpers/_str-to-num.scss
+++ b/app/assets/stylesheets/helpers/_str-to-num.scss
@@ -3,6 +3,11 @@
 // Source: http://sassmeister.com/gist/9647408
 //************************************************************************//
 @function _str-to-num($string) {
+  @if $output-bourbon-deprecation-warnings == true {
+    @warn "[Bourbon] [Deprecation] `_str-to-num` is " +
+    "deprecated and will be removed in 5.0.0.";
+  }
+
   // Matrices
   $strings: "0" "1" "2" "3" "4" "5" "6" "7" "8" "9";
   $numbers:  0   1   2   3   4   5   6   7   8   9;

--- a/app/assets/stylesheets/settings/_disable-warnings.scss
+++ b/app/assets/stylesheets/settings/_disable-warnings.scss
@@ -1,0 +1,8 @@
+@charset "UTF-8";
+
+/// Enable or disable output of Bourbon’s deprecation-related Sass warnings.
+/// This variable must be declared _before_ importing Bourbon.
+///
+/// @type Bool
+
+$output-bourbon-deprecation-warnings: true !default;


### PR DESCRIPTION
Introduce remaining deprecation warnings for features that are removed in 5.0.0.

This borrows heavily from how we deprecate features in Neat using Sass `@warn`: thoughtbot/neat@5c337cc

One key difference from Neat is that we only want to use this mixin for
deprecations, not _all_ warnings. The reason is because with CSS, it's not always
a straightforward task to upgrade libraries or frameworks; particularly major
releases. So we offer a toggle to globally disable deprecation warnings, but for
other meaningful warnings we need to throw, we still output those.

People can disable deprecation warnings by setting a variable to `false`:

```scss
$disable-bourbon-deprecation-warnings: true;
```

One problem with this system is that we cannot use these deprecation mixins to
deprecate a function. This is because Sass doesn't allow you to include a mixin
in a function. For now, since we only have a few functions up for deprecation,
we can live with this and manually write warnings for those.

**The plan is to merge this and release it as a `4.3` release to solely introduce
these warnings.**