### PR TITLE
Added value-prefixer

### DIFF
--- a/core/_bourbon.scss
+++ b/core/_bourbon.scss
@@ -47,4 +47,5 @@
 @import "bourbon/library/text-inputs";
 @import "bourbon/library/tint";
 @import "bourbon/library/triangle";
+@import "bourbon/library/value-prefixer";
 @import "bourbon/library/word-wrap";

--- a/core/bourbon/library/_value-prefixer.scss
+++ b/core/bourbon/library/_value-prefixer.scss
@@ -1,0 +1,38 @@
+@charset "UTF-8";
+
+/// Generates vendor prefixes for values.
+///
+/// @argument {string} $property
+///   Property to use.
+///
+/// @argument {string} $value
+///   Value to prefix.
+///
+/// @argument {list} $prefixes
+///   Vendor prefixes to output.
+///
+/// @example scss
+///   .element {
+///     @include prefixer(cursor, grab, ("webkit", "moz"));
+///   }
+///
+/// @example css
+///   .element {
+///     cursor: -webkit-grab;
+///     cursor: -moz-grab;
+///     cursor: grab;
+///   }
+///
+/// @author Matthew Tobiasz
+
+@mixin value-prefixer(
+    $property,
+    $value,
+    $prefixes: ()
+  ) {
+
+  @each $prefix in $prefixes {
+    $property: #{"-" + $prefix + "-" + $value};
+  }
+  $property: #{$value};
+}

--- a/core/bourbon/library/_value-prefixer.scss
+++ b/core/bourbon/library/_value-prefixer.scss
@@ -13,7 +13,7 @@
 ///
 /// @example scss
 ///   .element {
-///     @include prefixer(cursor, grab, ("webkit", "moz"));
+///     @include value-prefixer(cursor, grab, ("webkit", "moz"));
 ///   }
 ///
 /// @example css

--- a/core/bourbon/library/_value-prefixer.scss
+++ b/core/bourbon/library/_value-prefixer.scss
@@ -32,7 +32,7 @@
   ) {
 
   @each $prefix in $prefixes {
-    $property: #{"-" + $prefix + "-" + $value};
+    #{$property}: #{"-" + $prefix + "-" + $value};
   }
-  $property: #{$value};
+  #{$property}: $value;
 }


### PR DESCRIPTION
There are some non-standardized value prefixes (e.g., https://developer.mozilla.org/en-US/docs/Web/CSS/cursor ) that require a vendor prefix on the value to get working. I added a utility mixin to output those prefixes on values, very much like the existing prefixer mixin.