### PR TITLE
Remove word-break from the word-wrap mixin

### DIFF
--- a/core/bourbon/library/_word-wrap.scss
+++ b/core/bourbon/library/_word-wrap.scss
@@ -13,17 +13,10 @@
 /// @example css
 ///   .wrapper {
 ///     overflow-wrap: break-word;
-///     word-break: break-all;
 ///     word-wrap: break-word;
 ///   }
 
 @mixin word-wrap($wrap: break-word) {
   overflow-wrap: $wrap;
   word-wrap: $wrap;
-
-  @if $wrap == break-word {
-    word-break: break-all;
-  } @else {
-    word-break: $wrap;
-  }
 }

--- a/spec/bourbon/library/word_wrap_spec.rb
+++ b/spec/bourbon/library/word_wrap_spec.rb
@@ -9,8 +9,7 @@ describe "word-wrap" do
     it "adds word-wrap" do
       input = ".word-wrap"
       ruleset = "overflow-wrap: break-word; " +
-                "word-wrap: break-word; " +
-                "word-break: break-all;"
+                "word-wrap: break-word;"
 
       expect(input).to have_ruleset(ruleset)
     end
@@ -20,8 +19,7 @@ describe "word-wrap" do
     it "adds break" do
       input = ".word-wrap-break"
       ruleset = "overflow-wrap: normal; " +
-                "word-wrap: normal; " +
-                "word-break: normal;"
+                "word-wrap: normal;"
 
       expect(input).to have_ruleset(ruleset)
     end


### PR DESCRIPTION
The word-wrap mixin is just a wrapper for `word-break: break-all`. It doesn't make sense to have a word-wrap mixin when you can use word-break: break-all. See https://jsfiddle.net/0z7a9xtk/. I'm assuming the conditional statement with word-break: break-all was added to make it work in tables, but I think that should be left to the user to sort out.
