### PR TITLE
Add is-color validator

### DIFF
--- a/core/_bourbon.scss
+++ b/core/_bourbon.scss
@@ -12,6 +12,7 @@
 
 @import "bourbon/validators/contains";
 @import "bourbon/validators/contains-falsy";
+@import "bourbon/validators/is-color";
 @import "bourbon/validators/is-length";
 @import "bourbon/validators/is-light";
 @import "bourbon/validators/is-number";

--- a/core/bourbon/library/_contrast-switch.scss
+++ b/core/bourbon/library/_contrast-switch.scss
@@ -45,5 +45,16 @@
     $light-color: _retrieve-bourbon-setting("contrast-switch-light-color")
   ) {
 
-  @return if(_is-light($base-color), $dark-color, $light-color);
+  @if not _is-color($base-color) {
+    @error "`#{$base-color}` is not a valid color for the `$base-color` " +
+           "argument in the `contrast-switch` function.";
+  } @else if not _is-color($dark-color) {
+    @error "`#{$dark-color}` is not a valid color for the `$dark-color` " +
+           "argument in the `contrast-switch` function.";
+  } @else if not _is-color($light-color) {
+    @error "`#{$light-color}` is not a valid color for the `$light-color` " +
+           "argument in the `contrast-switch` function.";
+  } @else {
+    @return if(_is-light($base-color), $dark-color, $light-color);
+  }
 }

--- a/core/bourbon/library/_shade.scss
+++ b/core/bourbon/library/_shade.scss
@@ -24,5 +24,10 @@
     $percent
   ) {
 
-  @return mix(#000, $color, $percent);
+  @if not _is-color($color) {
+    @error "`#{$color}` is not a valid color for the `$color` argument in " +
+           "the `shade` mixin.";
+  } @else {
+    @return mix(#000, $color, $percent);
+  }
 }

--- a/core/bourbon/library/_size.scss
+++ b/core/bourbon/library/_size.scss
@@ -36,14 +36,14 @@
   @if _is-size($height) {
     height: $height;
   } @else {
-    @error "`#{$height}` is not a valid length for the `$height` parameter " +
+    @error "`#{$height}` is not a valid length for the `$height` argument " +
            "in the `size` mixin.";
   }
 
   @if _is-size($width) {
     width: $width;
   } @else {
-    @error "`#{$width}` is not a valid length for the `$width` parameter " +
+    @error "`#{$width}` is not a valid length for the `$width` argument " +
            "in the `size` mixin.";
   }
 }

--- a/core/bourbon/library/_tint.scss
+++ b/core/bourbon/library/_tint.scss
@@ -24,5 +24,10 @@
     $percent
   ) {
 
-  @return mix(#fff, $color, $percent);
+  @if not _is-color($color) {
+    @error "`#{$color}` is not a valid color for the `$color` argument in " +
+           "the `tint` mixin.";
+  } @else {
+    @return mix(#fff, $color, $percent);
+  }
 }

--- a/core/bourbon/library/_triangle.scss
+++ b/core/bourbon/library/_triangle.scss
@@ -45,6 +45,9 @@
     ) {
     @error "Direction must be `up`, `up-right`, `right`, `down-right`, " +
            "`down`, `down-left`, `left` or `up-left`.";
+  } @else if not _is-color($color) {
+    @error "`#{$color}` is not a valid color for the `$color` argument in " +
+           "the `triangle` mixin.";
   } @else {
     border-style: solid;
     height: 0;

--- a/core/bourbon/validators/_is-color.scss
+++ b/core/bourbon/validators/_is-color.scss
@@ -1,0 +1,13 @@
+@charset "UTF-8";
+
+/// Checks for a valid CSS color.
+///
+/// @argument {string} $color
+///
+/// @return {boolean}
+///
+/// @access private
+
+@function _is-color($color) {
+  @return (type-of($color) == color) or ($color == "currentColor");
+}


### PR DESCRIPTION
This function allows us to check user input for CSS colors when we expect one. If someone accidentally inputs a non-color, they’ll get a nice error message:

```
Error: `test` is not a valid color for the `$base-color` argument in the `contrast-switch` function.
```

To kick things off, I’ve added this validator to the `contrast-switch`, `shade` & `tint` functions, as well as the `triangle` mixin.