### PR TITLE
Run SassDoc on CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,7 @@
+dependencies:
+  override:
+    - bundle install
+    - npm install -g sassdoc
 general:
   branches:
     ignore:
@@ -5,3 +9,5 @@ general:
 test:
   override:
     - bundle exec rake
+  post:
+    - sassdoc core/ --parse --verbose --strict


### PR DESCRIPTION
We use [SassDoc](http://sassdoc.com/) for our documentation. This PR introduces a step within CircleCI to run SassDoc and parse the documentation; if it comes across an error, the build will fail. It would look like this:

<img width="741" alt="screen shot 2016-06-01 at 10 08 57" src="https://cloud.githubusercontent.com/assets/903327/15712591/eb32e1b0-27e0-11e6-981f-101ff1adcea7.png">
