### PR TITLE
Restructure documentation examples

### DIFF
--- a/core/bourbon/library/_border-color.scss
+++ b/core/bourbon/library/_border-color.scss
@@ -11,7 +11,7 @@
 ///     @include border-color(#a60b55 #76cd9c null #e8ae1a);
 ///   }
 ///
-/// @example css
+///   // CSS Output
 ///   .element {
 ///     border-left-color: #e8ae1a;
 ///     border-right-color: #76cd9c;

--- a/core/bourbon/library/_border-radius.scss
+++ b/core/bourbon/library/_border-radius.scss
@@ -10,7 +10,7 @@
 ///     @include border-top-radius(4px);
 ///   }
 ///
-/// @example css
+///   // CSS Output
 ///   .element {
 ///     border-top-left-radius: 4px;
 ///     border-top-right-radius: 4px;
@@ -31,7 +31,7 @@
 ///     @include border-right-radius(3px);
 ///   }
 ///
-/// @example css
+///   // CSS Output
 ///   .element {
 ///     border-bottom-right-radius: 3px;
 ///     border-top-right-radius: 3px;
@@ -52,7 +52,7 @@
 ///     @include border-bottom-radius(2px);
 ///   }
 ///
-/// @example css
+///   // CSS Output
 ///   .element {
 ///     border-bottom-left-radius: 2px;
 ///     border-bottom-right-radius: 2px;
@@ -73,7 +73,7 @@
 ///     @include border-left-radius(1px);
 ///   }
 ///
-/// @example css
+///   // CSS Output
 ///   .element {
 ///     border-bottom-left-radius: 1px;
 ///     border-top-left-radius: 1px;

--- a/core/bourbon/library/_border-style.scss
+++ b/core/bourbon/library/_border-style.scss
@@ -11,7 +11,7 @@
 ///     @include border-style(dashed null solid);
 ///   }
 ///
-/// @example css
+///   // CSS Output
 ///   .element {
 ///     border-bottom-style: solid;
 ///     border-top-style: dashed;

--- a/core/bourbon/library/_border-width.scss
+++ b/core/bourbon/library/_border-width.scss
@@ -11,7 +11,7 @@
 ///     @include border-width(1em null 20px);
 ///   }
 ///
-/// @example css
+///   // CSS Output
 ///   .element {
 ///     border-bottom-width: 20px;
 ///     border-top-width: 1em;

--- a/core/bourbon/library/_buttons.scss
+++ b/core/bourbon/library/_buttons.scss
@@ -16,7 +16,7 @@
 ///     background-color: #f00;
 ///   }
 ///
-/// @example css
+///   // CSS Output
 ///   button,
 ///   [type='button'],
 ///   [type='reset'],
@@ -35,7 +35,7 @@ $all-buttons: _assign-inputs($_buttons-list);
 ///     background-color: #00f;
 ///   }
 ///
-/// @example css
+///   // CSS Output
 ///   button:active,
 ///   [type='button']:active,
 ///   [type='reset']:active,
@@ -54,7 +54,7 @@ $all-buttons-active: _assign-inputs($_buttons-list, active);
 ///     background-color: #0f0;
 ///   }
 ///
-/// @example css
+///   // CSS Output
 ///   button:focus,
 ///   [type='button']:focus,
 ///   [type='reset']:focus,
@@ -73,7 +73,7 @@ $all-buttons-focus: _assign-inputs($_buttons-list, focus);
 ///     background-color: #0f0;
 ///   }
 ///
-/// @example css
+///   // CSS Output
 ///   button:hover,
 ///   [type='button']:hover,
 ///   [type='reset']:hover,

--- a/core/bourbon/library/_clearfix.scss
+++ b/core/bourbon/library/_clearfix.scss
@@ -9,7 +9,7 @@
 ///     @include clearfix;
 ///   }
 ///
-/// @example css
+///   // CSS Output
 ///   .element::after {
 ///     clear: both;
 ///     content: "";

--- a/core/bourbon/library/_contrast-switch.scss
+++ b/core/bourbon/library/_contrast-switch.scss
@@ -15,22 +15,24 @@
 /// @return {color}
 ///
 /// @example scss
-///   .first-element {
+///   .element {
 ///     color: contrast-switch(#bae6e6);
 ///   }
 ///
-///   .second-element {
+///   // CSS Output
+///   .element {
+///     color: #000;
+///   }
+///
+/// @example scss
+///   .element {
 ///     $button-color: #2d72d9;
 ///     background-color: $button-color;
 ///     color: contrast-switch($button-color, #222, #eee);
 ///   }
 ///
-/// @example css
-///   .first-element {
-///     color: #000;
-///   }
-///
-///   .second-element {
+///   // CSS Output
+///   .element {
 ///     background-color: #2d72d9;
 ///     color: #eee;
 ///   }

--- a/core/bourbon/library/_ellipsis.scss
+++ b/core/bourbon/library/_ellipsis.scss
@@ -13,7 +13,7 @@
 ///     @include ellipsis;
 ///   }
 ///
-/// @example css
+///   // CSS Output
 ///   .element {
 ///     display: inline-block;
 ///     max-width: 100%;

--- a/core/bourbon/library/_font-face.scss
+++ b/core/bourbon/library/_font-face.scss
@@ -32,7 +32,7 @@
 ///     font-weight: 400;
 ///   }
 ///
-/// @example css
+///   // CSS Output
 ///   @font-face {
 ///     font-family: "source-sans-pro";
 ///     src: url("fonts/source-sans-pro-regular.woff2") format("woff2"),

--- a/core/bourbon/library/_hide-text.scss
+++ b/core/bourbon/library/_hide-text.scss
@@ -10,7 +10,7 @@
 ///     @include hide-text;
 ///   }
 ///
-/// @example css
+///   // CSS Output
 ///   .element {
 ///     overflow: hidden;
 ///     text-indent: 101%;

--- a/core/bourbon/library/_hide-visually.scss
+++ b/core/bourbon/library/_hide-visually.scss
@@ -20,7 +20,7 @@
 ///     }
 ///   }
 ///
-/// @example css
+///   // CSS Output
 ///   .element {
 ///     border: 0;
 ///     clip: rect(1px, 1px, 1px, 1px);

--- a/core/bourbon/library/_margin.scss
+++ b/core/bourbon/library/_margin.scss
@@ -7,21 +7,23 @@
 ///   List of margin values, defined as CSS shorthand.
 ///
 /// @example scss
-///   .element-one {
+///   .element {
 ///     @include margin(null auto);
 ///   }
 ///
-///   .element-two {
-///     @include margin(10px 3em 20vh null);
-///   }
-///
-/// @example css
-///   .element-one {
+///   // CSS Output
+///   .element {
 ///     margin-left: auto;
 ///     margin-right: auto;
 ///   }
 ///
-///   .element-two {
+/// @example scss
+///   .element {
+///     @include margin(10px 3em 20vh null);
+///   }
+///
+///   // CSS Output
+///   .element {
 ///     margin-bottom: 20vh;
 ///     margin-right: 3em;
 ///     margin-top: 10px;

--- a/core/bourbon/library/_modular-scale.scss
+++ b/core/bourbon/library/_modular-scale.scss
@@ -19,41 +19,47 @@
 /// @return {number (with unit)}
 ///
 /// @example scss
-///   .first-element {
+///   .element {
 ///     font-size: modular-scale(2);
 ///   }
 ///
-///   .second-element {
+///   // CSS Output
+///   .element {
+///     font-size: 1.5625em;
+///   }
+///
+/// @example scss
+///   .element {
 ///     margin-right: modular-scale(3, 2em);
 ///   }
 ///
-///   .third-element {
+///   // CSS Output
+///   .element {
+///     margin-right: 3.90625em;
+///   }
+///
+/// @example scss
+///   .element {
 ///     font-size: modular-scale(3, 1em 1.6em, $major-seventh);
 ///   }
 ///
+///   // CSS Output
+///   .element {
+///     font-size: 3em;
+///   }
+///
+/// @example scss
 ///   // Globally change the base ratio
 ///   $bourbon: (
 ///     "modular-scale-ratio": 1.2,
 ///   );
 ///
-///   .fourth-element {
+///   .element {
 ///     font-size: modular-scale(3);
 ///   }
 ///
-/// @example css
-///   .first-element {
-///     font-size: 1.5625em;
-///   }
-///
-///   .second-element {
-///     margin-right: 3.90625em;
-///   }
-///
-///   .third-element {
-///     font-size: 3em;
-///   }
-///
-///   .fourth-element {
+///   // CSS Output
+///   .element {
 ///     font-size: 1.728em;
 ///   }
 ///

--- a/core/bourbon/library/_padding.scss
+++ b/core/bourbon/library/_padding.scss
@@ -11,16 +11,18 @@
 ///     @include padding(null 1rem);
 ///   }
 ///
-///   .element-two {
-///     @include padding(10vh null 10px 5%);
-///   }
-///
-/// @example css
+///   // CSS Output
 ///   .element-one {
 ///     padding-left: 1rem;
 ///     padding-right: 1rem;
 ///   }
 ///
+/// @example scss
+///   .element-two {
+///     @include padding(10vh null 10px 5%);
+///   }
+///
+///   // CSS Output
 ///   .element-two {
 ///     padding-bottom: 10px;
 ///     padding-left: 5%;

--- a/core/bourbon/library/_position.scss
+++ b/core/bourbon/library/_position.scss
@@ -14,7 +14,7 @@
 ///     @include position(absolute, 0 null null 10em);
 ///   }
 ///
-/// @example css
+///   // CSS Output
 ///   .element {
 ///     left: 10em;
 ///     position: absolute;

--- a/core/bourbon/library/_prefixer.scss
+++ b/core/bourbon/library/_prefixer.scss
@@ -16,7 +16,7 @@
 ///     @include prefixer(appearance, none, ("webkit", "moz"));
 ///   }
 ///
-/// @example css
+///   // CSS Output
 ///   .element {
 ///     -webkit-appearance: none;
 ///     -moz-appearance: none;

--- a/core/bourbon/library/_shade.scss
+++ b/core/bourbon/library/_shade.scss
@@ -14,7 +14,7 @@
 ///     background-color: shade(#ffbb52, 60%);
 ///   }
 ///
-/// @example css
+///   // CSS Output
 ///   .element {
 ///     background-color: #664a20;
 ///   }

--- a/core/bourbon/library/_size.scss
+++ b/core/bourbon/library/_size.scss
@@ -11,16 +11,18 @@
 ///     @include size(2em);
 ///   }
 ///
-///   .second-element {
-///     @include size(auto, 10em);
-///   }
-///
-/// @example css
+///   // CSS Output
 ///   .first-element {
 ///     width: 2em;
 ///     height: 2em;
 ///   }
 ///
+/// @example scss
+///   .second-element {
+///     @include size(auto, 10em);
+///   }
+///
+///   // CSS Output
 ///   .second-element {
 ///     width: auto;
 ///     height: 10em;

--- a/core/bourbon/library/_strip-unit.scss
+++ b/core/bourbon/library/_strip-unit.scss
@@ -9,7 +9,7 @@
 /// @example scss
 ///   $dimension: strip-unit(10em);
 ///
-/// @example css
+///   // Output
 ///   $dimension: 10;
 
 @function strip-unit($value) {

--- a/core/bourbon/library/_text-inputs.scss
+++ b/core/bourbon/library/_text-inputs.scss
@@ -16,7 +16,7 @@
 ///     border: 1px solid #ccc;
 ///   }
 ///
-/// @example css
+///   // CSS Output
 ///   [type='color'],
 ///   [type='date'],
 ///   [type='datetime'],
@@ -47,7 +47,7 @@ $all-text-inputs: _assign-inputs($_text-inputs-list);
 ///     border: 1px solid #aaa;
 ///   }
 ///
-/// @example css
+///   // CSS Output
 ///   [type='color']:active,
 ///   [type='date']:active,
 ///   [type='datetime']:active,
@@ -78,7 +78,7 @@ $all-text-inputs-active: _assign-inputs($_text-inputs-list, active);
 ///     border: 1px solid #1565c0;
 ///   }
 ///
-/// @example css
+///   // CSS Output
 ///   [type='color']:focus,
 ///   [type='date']:focus,
 ///   [type='datetime']:focus,
@@ -109,7 +109,7 @@ $all-text-inputs-focus: _assign-inputs($_text-inputs-list, focus);
 ///     border: 1px solid #aaa;
 ///   }
 ///
-/// @example css
+///   // CSS Output
 ///   [type='color']:hover,
 ///   [type='date']:hover,
 ///   [type='datetime']:hover,
@@ -140,7 +140,7 @@ $all-text-inputs-hover: _assign-inputs($_text-inputs-list, hover);
 ///     border: 1px solid #00f;
 ///   }
 ///
-/// @example css
+///   // CSS Output
 ///   [type='color']:invalid,
 ///   [type='date']:invalid,
 ///   [type='datetime']:invalid,

--- a/core/bourbon/library/_tint.scss
+++ b/core/bourbon/library/_tint.scss
@@ -14,7 +14,7 @@
 ///     background-color: tint(#6ecaa6, 40%);
 ///   }
 ///
-/// @example css
+///   // CSS Output
 ///   .element {
 ///     background-color: #a8dfc9;
 ///   }

--- a/core/bourbon/library/_triangle.scss
+++ b/core/bourbon/library/_triangle.scss
@@ -23,7 +23,7 @@
 ///     }
 ///   }
 ///
-/// @example css
+///   // CSS Output
 ///   .element::before {
 ///     border-style: solid;
 ///     height: 0;

--- a/core/bourbon/library/_value-prefixer.scss
+++ b/core/bourbon/library/_value-prefixer.scss
@@ -16,7 +16,7 @@
 ///     @include value-prefixer(cursor, grab, ("webkit", "moz"));
 ///   }
 ///
-/// @example css
+///   // CSS Output
 ///   .element {
 ///     cursor: -webkit-grab;
 ///     cursor: -moz-grab;

--- a/core/bourbon/library/_word-wrap.scss
+++ b/core/bourbon/library/_word-wrap.scss
@@ -10,7 +10,7 @@
 ///     @include word-wrap(break-word);
 ///   }
 ///
-/// @example css
+///   // CSS Output
 ///   .wrapper {
 ///     overflow-wrap: break-word;
 ///     word-break: break-all;

--- a/core/bourbon/utilities/_collapse-directionals.scss
+++ b/core/bourbon/utilities/_collapse-directionals.scss
@@ -10,13 +10,13 @@
 /// @argument {list} $values
 ///   List of directional values.
 ///
-/// @example scss - Usage
+/// @example scss
 ///   .element {
 ///     @include border-style(dotted null);
 ///     @include margin(null 0 10px);
 ///   }
 ///
-/// @example css - CSS Output
+///   // CSS Output
 ///   .element {
 ///     border-bottom-style: dotted;
 ///     border-top-style: dotted;

--- a/core/bourbon/utilities/_unpack.scss
+++ b/core/bourbon/utilities/_unpack.scss
@@ -9,7 +9,7 @@
 ///     margin: _unpack(1em 2em);
 ///   }
 ///
-/// @example css
+///   // CSS Output
 ///   .element {
 ///     margin: 1em 2em 1em 2em;
 ///   }


### PR DESCRIPTION
We currently use SassDoc's `@example` annotation by putting the Sass
within the first `@example` block, and then the output CSS in a second
`@example` block.

```scss
/// @example scss
///   .element {
///     @include border-top-radius(4px);
///   }
///
/// @example css
///   .element {
///     border-top-left-radius: 4px;
///     border-top-right-radius: 4px;
///   }
```

This is a bit confusing to follow input/output when a feature has
multiple examples.

```scss
/// @example scss
///   .first-element {
///     font-size: modular-scale(2);
///   }
///
///   .second-element {
///     margin-right: modular-scale(3, 2em);
///   }
///
///   .third-element {
///     font-size: modular-scale(3, 1em 1.6em, $major-seventh);
///   }
///
///   // Globally change the base ratio
///   $bourbon: (
///     "modular-scale-ratio": 1.2,
///   );
///
///   .fourth-element {
///     font-size: modular-scale(3);
///   }
///
/// @example css
///   .first-element {
///     font-size: 1.5625em;
///   }
///
///   .second-element {
///     margin-right: 3.90625em;
///   }
///
///   .third-element {
///     font-size: 3em;
///   }
///
///   .fourth-element {
///     font-size: 1.728em;
///   }
```

This also means that we can't describe individual examples very well
since SassDoc supports a description per `@example` block.

Since SassDoc doesn't currently have the concept of input/output, this
commit encapsulated each example in its own `@example` block, using a
CSS comment to indicate the output.

### What does this PR do?

With this change, the documentation site can have a better understanding
of what an example is, and easily loop through multiple consistent
examples.

```scss
/// @example scss
///   .element {
///     font-size: modular-scale(2);
///   }
///
///   // CSS Output
///   .element {
///     font-size: 1.5625em;
///   }
```