### PR TITLE
prepend inputs with parent selector through loop

### DIFF
--- a/core/bourbon/utilities/_assign-inputs.scss
+++ b/core/bourbon/utilities/_assign-inputs.scss
@@ -14,7 +14,8 @@
 
 @function _assign-inputs(
     $inputs,
-    $pseudo: null
+    $pseudo: null,
+    $parent-selector: null
   ) {
 
   $list: ();
@@ -22,6 +23,7 @@
   @each $input in $inputs {
     $input: unquote($input);
     $input: if($pseudo, $input + ":" + $pseudo, $input);
+    $input: if($parent-selector, $parent-selector + " " + $input, $input);
     $list: append($list, $input, comma);
   }
 

--- a/spec/bourbon/utilities/assign_inputs_spec.rb
+++ b/spec/bourbon/utilities/assign_inputs_spec.rb
@@ -18,7 +18,7 @@ describe "assign-inputs" do
     end
   end
 
-  context "expands text inputs with pseudo classes" do
+  context "pseudo class provided" do
     it "finds selectors" do
       list = @text_inputs_list.dup
       list.map! { |input| input + ":active" }
@@ -44,6 +44,28 @@ describe "assign-inputs" do
       list.unshift "[type=\"file\"]"
       list.each do |input|
         expect(input).to have_rule("color: #f0f")
+      end
+    end
+  end
+
+  context "parent selector provided" do
+    it "prepends parent selector to each input" do
+      list = @text_inputs_list.dup
+      inputs_with_parent_selector = list.map! { |input| ".class " + input }
+      inputs_with_parent_selector.each do |selector|
+        expect(selector).to have_rule("color: #ddd")
+      end
+    end
+  end
+
+  context "parent selector and psuedo class provided" do
+    it "prepends parent selector and appends pseudo class to each input" do
+      list = @text_inputs_list.dup
+      inputs_with_psuedo_class = list.map! { |input| input + ":active" }
+      inputs_with_parent_selector =
+        inputs_with_psuedo_class.map! { |input| ".class " + input }
+      inputs_with_parent_selector.each do |selector|
+        expect(selector).to have_rule("color: #eee")
       end
     end
   end

--- a/spec/fixtures/utilities/assign-inputs.scss
+++ b/spec/fixtures/utilities/assign-inputs.scss
@@ -17,3 +17,11 @@ select {
 #{_assign-inputs($_text-inputs-list)} {
   color: #f0f;
 }
+
+#{_assign-inputs($_text-inputs-list, null, ".class")} {
+  color: #ddd;
+}
+
+#{_assign-inputs($_text-inputs-list, active, ".class")} {
+  color: #eee;
+}


### PR DESCRIPTION
### What problem am I trying to solve?

I wanted $all-text-inputs to have styling when those inputs are nested within a certain class. This can currently be done by nesting: 

```
.parent-class {
  $all-text-inputs {
    ...
  }
}
```

However, it was less ideal when trying to expand those same styles to non-nested classes, while trying to maintain DRY Sass files. For example, we were looking to do:

```
.parent-class $all-text-inputs,
.cousin-class,
.maybe-something-else {
  ...
}
```

Clearly, this produces undesired css: the first text input would be prepended with the `.parent-class`, but none of the following inputs would. 

### What does this PR do?

This PR extends the existing functionality of the `_assign_inputs` function to accept a parent-selector that then gets prepended during the loop, in the same way the `pseudo` classes do.

### Critiques of this approach?

* Theoretically, we could go on forever, making this apply to child-selectors and so on. That could become onerous.
* One way around this is to add another class to the items identified in my example above. This is not ideal when using form auto-generation, like [Simple Form](https://github.com/plataformatec/simple_form).
* Another way around this is to add a local function that would loop through the inputs and prepend them. This is not ideal as the `$all-text-inputs` already has the comma separation. 
* Anything else?
