### PR TITLE
Update position mixin

### DIFF
--- a/core/bourbon/library/_position.scss
+++ b/core/bourbon/library/_position.scss
@@ -30,7 +30,7 @@
     $coordinates: null
   ) {
 
-  @if type-of($position) == list {
+  @if type-of($position) == list or _is-length($position) {
     $coordinates: $position;
     $position: relative;
   }


### PR DESCRIPTION
### What does this PR do?
Fixes position mixin when called with only a single length value. 

this works now, and failed before:
`.x { @include position(0); }`

### If this is related to an existing issue, include a link to it as well.
no related issue found