### PR TITLE
Remove argument defaults from position mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ project adheres to [Semantic Versioning](http://semver.org).
 
 ## [Unreleased]
 
+### Changed
+
+- Removed the default values from the `$position` and `$coordinates` arguments
+  for the `position` mixin.
+
 [Unreleased]: https://github.com/thoughtbot/bourbon/compare/v5.0.0.beta.6...HEAD
 
 ## [5.0.0-beta.6] - 2016-06-06

--- a/core/bourbon/library/_position.scss
+++ b/core/bourbon/library/_position.scss
@@ -1,24 +1,39 @@
 @charset "UTF-8";
 
-/// Provides a quick method for setting an element’s position. Use a `null`
-/// value to “skip” a side.
+/// Provides a concise, one-line method for setting an element’s positioning
+/// properties: `position`, `top`, `right`, `bottom` and `left`. Use a `null`
+/// value to “skip” an edge of the box.
 ///
-/// @argument {string} $position [relative]
+/// @argument {string} $position
 ///   A CSS position value.
 ///
-/// @argument {arglist} $coordinates [null]
-///   List of lengths, defined as CSS shorthand.
+/// @argument {list} $coordinates
+///   List of lengths; accepts CSS shorthand.
 ///
 /// @example scss
 ///   .element {
-///     @include position(absolute, 0 null null 10em);
+///     @include position(relative, 0 null null 10em);
 ///   }
 ///
 ///   // CSS Output
 ///   .element {
 ///     left: 10em;
+///     position: relative;
+///     top: 0;
+///   }
+///
+/// @example scss
+///   .element {
+///     @include position(absolute, 0);
+///   }
+///
+///   // CSS Output
+///   .element {
 ///     position: absolute;
 ///     top: 0;
+///     right: 0;
+///     bottom: 0;
+///     left: 0;
 ///   }
 ///
 /// @require {function} _is-length
@@ -26,14 +41,9 @@
 /// @require {function} _unpack
 
 @mixin position(
-    $position: relative,
-    $coordinates: null
+    $position,
+    $coordinates
   ) {
-
-  @if type-of($position) == list {
-    $coordinates: $position;
-    $position: relative;
-  }
 
   $coordinates: _unpack($coordinates);
 

--- a/spec/fixtures/library/position.scss
+++ b/spec/fixtures/library/position.scss
@@ -1,9 +1,5 @@
 @import "setup";
 
-.position-only-type {
-  @include position(relative);
-}
-
 .position-all {
   @include position(fixed, 1em);
 }


### PR DESCRIPTION
- Remove default value for the `$position` argument because it is
unclear if it is not defined when calling the mixin.
- Remove default value for the `$coordinates` argument because it is
unclear if it is not defined when calling the mixin.
- This also updates the documentation to show use of shorthand.
- Remove unused spec CSS.
- Related discussion: https://github.com/thoughtbot/bourbon/pull/947.

--

TL;DR

The mixin is currently setup to do this:

```scss
@include position(relative);

// output
position: relative;
top: 0;
right: 0;
bottom: 0;
left: 0;
```

…and:

```scss
@include position(0 10px);

// output
position: relative;
top: 0;
right: 10px;
bottom: 0;
left: 10px;
```

But these are unclear by not declaring _both_ arguments.