### PR TITLE
Improve accessibility on hide-visually mixin

### DIFF
--- a/core/bourbon/library/_hide-visually.scss
+++ b/core/bourbon/library/_hide-visually.scss
@@ -53,6 +53,7 @@
     overflow: hidden;
     padding: 0;
     position: absolute;
+    white-space: nowrap;
     width: 1px;
   } @else if $toggle == "unhide" {
     clip: auto;
@@ -60,6 +61,7 @@
     height: auto;
     overflow: visible;
     position: static;
+    white-space: inherit;
     width: auto;
   }
 }

--- a/spec/bourbon/library/hide_visually_spec.rb
+++ b/spec/bourbon/library/hide_visually_spec.rb
@@ -14,6 +14,7 @@ describe "hide-visually" do
                 "overflow: hidden; " +
                 "padding: 0; " +
                 "position: absolute; " +
+                "white-space: nowrap; " +
                 "width: 1px;"
 
       expect(".hide-visually").to have_ruleset(ruleset)
@@ -27,6 +28,7 @@ describe "hide-visually" do
                 "height: auto; " +
                 "overflow: visible; " +
                 "position: static; " +
+                "white-space: inherit; " +
                 "width: auto;"
 
       expect(".hide-visually--unhide").to have_ruleset(ruleset)


### PR DESCRIPTION
Add `white-space: nowrap;` to hide-visually mixin, and reset it back to `inherit` when unhiding.

Screen readers don't interpret line breaks as spaces, so force visually hidden content onto one line so spaces are retained and screen readers can read the content properly.

See #944 

