### PR TITLE
Update `$font-stack-system` list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,12 @@ project adheres to [Semantic Versioning](http://semver.org).
   full compliance, though all of our manual testing passed.
 - Renamed the `$coordinates` argument in the `position` mixin
   to `$box-edge-values`.
+- Updated `$font-stack-system` to include Avenir Next, Avenir, Lucida
+  Grande, Helvetica, Noto, Franklin Gothic Medium, Century Gothic, and
+  Liberation Sans. This follows [system-fonts] by Adam Morse.
 
 [Unreleased]: https://github.com/thoughtbot/bourbon/compare/v5.0.0.beta.6...HEAD
+[system-fonts]: https://github.com/mrmrs/css-system-fonts
 
 ## [5.0.0-beta.6] - 2016-06-06
 

--- a/core/bourbon/library/_font-stacks.scss
+++ b/core/bourbon/library/_font-stacks.scss
@@ -27,17 +27,27 @@ $font-stack-verdana: (
   sans-serif,
 );
 
+/// @link https://goo.gl/LHRZIf
+
 $font-stack-system: (
   -apple-system,
   BlinkMacSystemFont,
+  "Avenir Next",
+  "Avenir",
   "Segoe UI",
+  "Lucida Grande",
+  "Helvetica Neue",
+  "Helvetica",
+  "Fira Sans",
   "Roboto",
+  "Noto",
+  "Droid Sans",
+  "Cantarell",
   "Oxygen",
   "Ubuntu",
-  "Cantarell",
-  "Fira Sans",
-  "Droid Sans",
-  "Helvetica Neue",
+  "Franklin Gothic Medium",
+  "Century Gothic",
+  "Liberation Sans",
   sans-serif,
 );
 

--- a/spec/bourbon/library/font_stacks_spec.rb
+++ b/spec/bourbon/library/font_stacks_spec.rb
@@ -21,9 +21,11 @@ describe "font-stacks" do
                     '"Lucida Typewriter", monospace'
       monaco = '"monaco", "Consolas", "Lucida Console", monospace'
 
-      system = '-apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", ' +
-               '"Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", ' +
-               '"Helvetica Neue", sans-serif'
+      system = '-apple-system, BlinkMacSystemFont, "Avenir Next", "Avenir", ' +
+               '"Segoe UI", "Lucida Grande", "Helvetica Neue", "Helvetica", ' +
+               '"Fira Sans", "Roboto", "Noto", "Droid Sans", "Cantarell", ' +
+               '"Oxygen", "Ubuntu", "Franklin Gothic Medium", ' +
+               '"Century Gothic", "Liberation Sans", sans-serif'
 
       expect(".helvetica").to have_value(helvetica)
       expect(".lucida-grande").to have_value(lucida_grande)


### PR DESCRIPTION
### What does this PR do?
- Updates the `$font-stack-system` list to include more fonts.
- Follows Adam Morse's system-fonts: https://github.com/mrmrs/css-system-fonts
### To do
- [x] Update Change Log
