### PR TITLE
Rename unpack to unpack-shorthand

### DIFF
--- a/core/_bourbon.scss
+++ b/core/_bourbon.scss
@@ -22,7 +22,7 @@
 @import "bourbon/utilities/directional-property";
 @import "bourbon/utilities/font-source-declaration";
 @import "bourbon/utilities/retrieve-bourbon-setting";
-@import "bourbon/utilities/unpack";
+@import "bourbon/utilities/unpack-shorthand";
 
 @import "bourbon/library/border-color";
 @import "bourbon/library/border-radius";

--- a/core/bourbon/library/_position.scss
+++ b/core/bourbon/library/_position.scss
@@ -38,14 +38,14 @@
 ///
 /// @require {function} _is-length
 ///
-/// @require {function} _unpack
+/// @require {function} _unpack-shorthand
 
 @mixin position(
     $position,
     $coordinates
   ) {
 
-  $coordinates: _unpack($coordinates);
+  $coordinates: _unpack-shorthand($coordinates);
 
   $offsets: (
     top:    nth($coordinates, 1),

--- a/core/bourbon/utilities/_unpack-shorthand.scss
+++ b/core/bourbon/utilities/_unpack-shorthand.scss
@@ -1,12 +1,12 @@
 @charset "UTF-8";
 
-/// Converts shorthand to the 4-value syntax.
+/// Transforms shorthand that can range from 1-to-4 values to be 4 values.
 ///
 /// @argument {list} $shorthand
 ///
 /// @example scss
 ///   .element {
-///     margin: _unpack(1em 2em);
+///     margin: _unpack-shorthand(1em 2em);
 ///   }
 ///
 ///   // CSS Output
@@ -16,7 +16,7 @@
 ///
 /// @access private
 
-@function _unpack($shorthand) {
+@function _unpack-shorthand($shorthand) {
   @if length($shorthand) == 1 {
     @return nth($shorthand, 1) nth($shorthand, 1) nth($shorthand, 1) nth($shorthand, 1);
   } @else if length($shorthand) == 2 {

--- a/spec/fixtures/utilities/unpack.scss
+++ b/spec/fixtures/utilities/unpack.scss
@@ -1,17 +1,17 @@
 @import "setup";
 
 .single {
-  padding: _unpack(10px);
+  padding: _unpack-shorthand(10px);
 }
 
 .double {
-  padding: _unpack(1em 2em);
+  padding: _unpack-shorthand(1em 2em);
 }
 
 .triple {
-  padding: _unpack(10px 20px 0);
+  padding: _unpack-shorthand(10px 20px 0);
 }
 
 .quadruple {
-  padding: _unpack(0 calc(1em + 10px) 20px 50px);
+  padding: _unpack-shorthand(0 calc(1em + 10px) 20px 50px);
 }


### PR DESCRIPTION
## What does this PR do?

- The name `unpack-shorthand` better describes what the function does.
- Updated the documentation description to more clearly describe what the
function does.