### PR TITLE
Rename position mixin argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ project adheres to [Semantic Versioning](http://semver.org).
 - Updated `contrast-switch` to calculate contrast based on the WCAG 2.0
   specification. Please note that it is an approximation and we cannot guarantee
   full compliance, though all of our manual testing passed.
+- Renamed the `$coordinates` argument in the `position` mixin
+  to `$box-edge-values`.
 
 [Unreleased]: https://github.com/thoughtbot/bourbon/compare/v5.0.0.beta.6...HEAD
 

--- a/core/bourbon/library/_position.scss
+++ b/core/bourbon/library/_position.scss
@@ -7,7 +7,7 @@
 /// @argument {string} $position
 ///   A CSS position value.
 ///
-/// @argument {list} $coordinates
+/// @argument {list} $box-edge-values
 ///   List of lengths; accepts CSS shorthand.
 ///
 /// @example scss
@@ -42,16 +42,16 @@
 
 @mixin position(
     $position,
-    $coordinates
+    $box-edge-values
   ) {
 
-  $coordinates: _unpack-shorthand($coordinates);
+  $box-edge-values: _unpack-shorthand($box-edge-values);
 
   $offsets: (
-    top:    nth($coordinates, 1),
-    right:  nth($coordinates, 2),
-    bottom: nth($coordinates, 3),
-    left:   nth($coordinates, 4),
+    top:    nth($box-edge-values, 1),
+    right:  nth($box-edge-values, 2),
+    bottom: nth($box-edge-values, 3),
+    left:   nth($box-edge-values, 4),
   );
 
   position: $position;


### PR DESCRIPTION
### What does this PR do?

- Renames the `$coordinates` argument in the `position` mixin to `$box-edge-values`.