### PR TITLE
Fixing "user-select" mixin on Chrome for Android

### DIFF
--- a/app/assets/stylesheets/css3/_user-select.scss
+++ b/app/assets/stylesheets/css3/_user-select.scss
@@ -2,4 +2,9 @@
   @include _bourbon-deprecate-for-prefixing("user-select");
 
   @include prefixer(user-select, $value, webkit moz ms spec);
+
+  // See http://stackoverflow.com/a/30319808/21290
+  @if $value == none {
+    -webkit-tap-highlight-color: transparent;
+  }
 }


### PR DESCRIPTION
Fixes the `user-select` mixin in case `value==none` and running on Chrome on a touch device.
