### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,6 @@ The current version is **4.2.7**. The `master` branch on GitHub is version
 
 ## Installation
 
-**Note:** In order to use the features described in the current
-[documentation](http://bourbon.io/docs) you will need to specify version **4.2.7**
-as the gem version in each of the installation options below.
-
 1. Install the Bourbon gem using the [RubyGems] package manager:
 
   ```bash

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The current version is **4.2.7**. The `master` branch on GitHub is version
 
 ### Helpful Links
 
-- [Documentation](http://bourbon.io/docs/latest/)
+- [Documentation](http://bourbon.io/docs)
 - [Change log](CHANGELOG.md)
 - [Twitter](https://twitter.com/bourbonsass)
 
@@ -42,6 +42,10 @@ The current version is **4.2.7**. The `master` branch on GitHub is version
   [LibSass]: https://github.com/sass/libsass
 
 ## Installation
+
+**Note:** In order to use the features described in the current
+[documentation](http://bourbon.io/docs) you will need to specify version **4.2.7**
+as the gem version in each of the installation options below.
 
 1. Install the Bourbon gem using the [RubyGems] package manager:
 


### PR DESCRIPTION
### What does this PR do?

Updates two lines in the PR:

**Line 22:** Updates the link to bourbon documentation.
**Line 46:** Adds a line to indicate that users will need to specify version 4.2.7 of the Bourbon gem in order to take advantage of currently documented functionality.

### If this is related to an existing issue, include a link to it as well.

### Screenshots (if relevant)

