### PR TITLE
Add style property to package.json, allowing for easier imports.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   ],
   "license": "MIT",
   "main": "index.js",
+  "style": "app/assets/stylesheets/_bourbon.scss",
   "name": "bourbon",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "license": "MIT",
   "main": "index.js",
-  "style": "app/assets/stylesheets/_bourbon.scss",
+  "style": "core/_bourbon.scss",
   "name": "bourbon",
   "repository": {
     "type": "git",


### PR DESCRIPTION
When installed via npm, a style property in package.json allows this module to be easily imported when using tools such as [npm-sass](https://github.com/lennym/npm-sass) or [sass-module-importer](https://www.npmjs.com/package/sass-module-importer).

Apparently the "style" key is not a standard, but it is a growing trend. Here's a StackOverflow thread on the subject: http://stackoverflow.com/questions/32037150/style-field-in-package-json