### PR TITLE
Correct version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It is…
 - Lightweight: Zero output post-install and has no visual opinion.
 
 The current version is **4.2.7**. The `master` branch on GitHub is version
-5.0.0-beta.7.
+5.0.0.beta.7.
 
   [Bourbon]: http://bourbon.io
   [Sass]: http://sass-lang.com


### PR DESCRIPTION
### What does this PR do?

Replaces hyphen with dot in version number as displayed in README:

`5.0.0-beta.7` --> `5.0.0.beta.7`

### If this is related to an existing issue, include a link to it as well.

### Screenshots (if relevant)

