### PR TITLE
Remove triangle mixin’s default argument values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,14 @@
 All notable changes to this project will be documented in this file. This
 project adheres to [Semantic Versioning](http://semver.org).
 
-## [Unreleased]
+## [Unreleased (`master`)][unreleased]
 
-Nothing at the moment.
+### Changed
 
-[Unreleased]: https://github.com/thoughtbot/bourbon/compare/v5.0.0.beta.7...HEAD
+- The `triangle` mixin no longer has default argument values. The order of the
+  arguments also changed: `$width` and `$height` now come before `$color`.
+
+[unreleased]: https://github.com/thoughtbot/bourbon/compare/v5.0.0.beta.7...HEAD
 
 ## [5.0.0-beta.7] - 2016-11-03
 

--- a/core/bourbon/library/_triangle.scss
+++ b/core/bourbon/library/_triangle.scss
@@ -2,23 +2,23 @@
 
 /// Generates a triangle pointing in a specified direction.
 ///
-/// @argument {string} $direction [up]
+/// @argument {string} $direction
 ///   The direction the triangle should point. Accepts `up`, `up-right`,
 ///   `right`, `down-right`, `down`, `down-left`, `left` or `up-left`.
 ///
-/// @argument {color} $color [currentColor]
-///   Color of the triangle.
-///
-/// @argument {number (with unit)} $width [1rem]
+/// @argument {number (with unit)} $width
 ///   Width of the triangle.
 ///
-/// @argument {number (with unit)} $height [($width / 2)]
+/// @argument {number (with unit)} $height
 ///   Height of the triangle.
+///
+/// @argument {color} $color
+///   Color of the triangle.
 ///
 /// @example scss
 ///   .element {
 ///     &::before {
-///       @include triangle(up, #b25c9c, 2rem);
+///       @include triangle("up", 2rem, 1rem, #b25c9c);
 ///       content: "";
 ///     }
 ///   }
@@ -28,16 +28,16 @@
 ///     border-style: solid;
 ///     height: 0;
 ///     width: 0;
-///     border-color: transparent transparent #b25c9c transparent;
+///     border-color: transparent transparent #b25c9c;
 ///     border-width: 0 1rem 1rem;
 ///     content: "";
 ///   }
 
 @mixin triangle(
-    $direction: up,
-    $color: currentColor,
-    $width: 1rem,
-    $height: ($width / 2)
+    $direction,
+    $width,
+    $height,
+    $color
   ) {
   @if not index(
       "up" "up-right" "right" "down-right" "down" "down-left" "left" "up-left",

--- a/spec/bourbon/library/triangle_spec.rb
+++ b/spec/bourbon/library/triangle_spec.rb
@@ -10,10 +10,10 @@ describe "triangle" do
       ruleset = "border-style: solid; " +
                 "height: 0; " +
                 "width: 0; " +
-                "border-color: transparent transparent currentColor; " +
-                "border-width: 0 0.5rem 0.5rem;"
+                "border-color: transparent transparent #b25c9c; " +
+                "border-width: 0 1rem 1rem;"
 
-      expect(".triangle").to have_ruleset(ruleset)
+      expect(".triangle--up").to have_ruleset(ruleset)
     end
   end
 
@@ -22,10 +22,10 @@ describe "triangle" do
       ruleset = "border-style: solid; " +
                 "height: 0; " +
                 "width: 0; " +
-                "border-color: #b25c9c transparent transparent; " +
-                "border-width: 20px 15px 0;"
+                "border-color: transparent transparent transparent #aaa; " +
+                "border-width: 6px 0 6px 5px;"
 
-      expect(".triangle--with-arguments").to have_ruleset(ruleset)
+      expect(".triangle--right").to have_ruleset(ruleset)
     end
   end
 end

--- a/spec/fixtures/library/triangle.scss
+++ b/spec/fixtures/library/triangle.scss
@@ -1,9 +1,9 @@
 @import "setup";
 
-.triangle {
-  @include triangle;
+.triangle--up {
+  @include triangle("up", 2rem, 1rem, #b25c9c);
 }
 
-.triangle--with-arguments {
-  @include triangle(down, #b25c9c, 30px, 20px);
+.triangle--right {
+  @include triangle("right", 5px, 12px, #aaa);
 }


### PR DESCRIPTION
- These values are very use-case specific, e.g. matching the color of
whatever component it is used on.
- The size arguments also acted unexpectedly because the shape of the
triangle when defining only the width would be different based on if it
was the up/down or right/left direction.
- By requiring all four arguments to be defined, it forces consistency
and clarity.
- The order of the arguments was also adjusted so that those relating to
the "box" the triangle sits in are grouped.
- Closes https://github.com/thoughtbot/bourbon/issues/994

## Before

```scss
@include triangle("up", #b25c9c, 2rem);
```

## After

```scss
@include triangle("up", 2rem, 1rem, #b25c9c);
```