### PR TITLE
Suppress deprecation warnings when called from bourbon

### DIFF
--- a/app/assets/stylesheets/addons/_border-color.scss
+++ b/app/assets/stylesheets/addons/_border-color.scss
@@ -22,5 +22,8 @@
 /// @output `border-color`
 
 @mixin border-color($vals...) {
+  $deprecation-warnings: $output-bourbon-deprecation-warnings;
+  $output-bourbon-deprecation-warnings: false !global;
   @include directional-property(border, color, $vals...);
+  $output-bourbon-deprecation-warnings: $deprecation-warnings !global;
 }

--- a/app/assets/stylesheets/addons/_border-color.scss
+++ b/app/assets/stylesheets/addons/_border-color.scss
@@ -22,8 +22,8 @@
 /// @output `border-color`
 
 @mixin border-color($vals...) {
-  $deprecation-warnings: $output-bourbon-deprecation-warnings;
+  $user-deprecation-warnings-setting: $output-bourbon-deprecation-warnings;
   $output-bourbon-deprecation-warnings: false !global;
   @include directional-property(border, color, $vals...);
-  $output-bourbon-deprecation-warnings: $deprecation-warnings !global;
+  $output-bourbon-deprecation-warnings: $user-deprecation-warnings-setting !global;
 }

--- a/app/assets/stylesheets/addons/_border-style.scss
+++ b/app/assets/stylesheets/addons/_border-style.scss
@@ -21,5 +21,8 @@
 /// @output `border-style`
 
 @mixin border-style($vals...) {
+  $deprecation-warnings: $output-bourbon-deprecation-warnings;
+  $output-bourbon-deprecation-warnings: false !global;
   @include directional-property(border, style, $vals...);
+  $output-bourbon-deprecation-warnings: $deprecation-warnings !global;
 }

--- a/app/assets/stylesheets/addons/_border-style.scss
+++ b/app/assets/stylesheets/addons/_border-style.scss
@@ -21,8 +21,8 @@
 /// @output `border-style`
 
 @mixin border-style($vals...) {
-  $deprecation-warnings: $output-bourbon-deprecation-warnings;
+  $user-deprecation-warnings-setting: $output-bourbon-deprecation-warnings;
   $output-bourbon-deprecation-warnings: false !global;
   @include directional-property(border, style, $vals...);
-  $output-bourbon-deprecation-warnings: $deprecation-warnings !global;
+  $output-bourbon-deprecation-warnings: $user-deprecation-warnings-setting !global;
 }

--- a/app/assets/stylesheets/addons/_border-width.scss
+++ b/app/assets/stylesheets/addons/_border-width.scss
@@ -21,5 +21,8 @@
 /// @output `border-width`
 
 @mixin border-width($vals...) {
+  $deprecation-warnings: $output-bourbon-deprecation-warnings;
+  $output-bourbon-deprecation-warnings: false !global;
   @include directional-property(border, width, $vals...);
+  $output-bourbon-deprecation-warnings: $deprecation-warnings !global;
 }

--- a/app/assets/stylesheets/addons/_border-width.scss
+++ b/app/assets/stylesheets/addons/_border-width.scss
@@ -21,8 +21,8 @@
 /// @output `border-width`
 
 @mixin border-width($vals...) {
-  $deprecation-warnings: $output-bourbon-deprecation-warnings;
+  $user-deprecation-warnings-setting: $output-bourbon-deprecation-warnings;
   $output-bourbon-deprecation-warnings: false !global;
   @include directional-property(border, width, $vals...);
-  $output-bourbon-deprecation-warnings: $deprecation-warnings !global;
+  $output-bourbon-deprecation-warnings: $user-deprecation-warnings-setting !global;
 }

--- a/app/assets/stylesheets/addons/_buttons.scss
+++ b/app/assets/stylesheets/addons/_buttons.scss
@@ -53,7 +53,7 @@ $buttons-list: 'button',
                'input[type="reset"]',
                'input[type="submit"]';
 
-$output-bourbon-deprecation-warnings-original: $output-bourbon-deprecation-warnings;
+$user-output-deprecation-warnings-setting: $output-bourbon-deprecation-warnings;
 $output-bourbon-deprecation-warnings: false;
 
 $all-buttons:        assign-inputs($buttons-list);
@@ -61,7 +61,7 @@ $all-buttons-active: assign-inputs($buttons-list, active);
 $all-buttons-focus:  assign-inputs($buttons-list, focus);
 $all-buttons-hover:  assign-inputs($buttons-list, hover);
 
-$output-bourbon-deprecation-warnings: $output-bourbon-deprecation-warnings-original;
+$output-bourbon-deprecation-warnings: $user-output-deprecation-warnings-setting;
 
 $all-button-inputs:        $all-buttons;
 $all-button-inputs-active: $all-buttons-active;

--- a/app/assets/stylesheets/addons/_buttons.scss
+++ b/app/assets/stylesheets/addons/_buttons.scss
@@ -53,10 +53,15 @@ $buttons-list: 'button',
                'input[type="reset"]',
                'input[type="submit"]';
 
+$output-bourbon-deprecation-warnings-original: $output-bourbon-deprecation-warnings;
+$output-bourbon-deprecation-warnings: false;
+
 $all-buttons:        assign-inputs($buttons-list);
 $all-buttons-active: assign-inputs($buttons-list, active);
 $all-buttons-focus:  assign-inputs($buttons-list, focus);
 $all-buttons-hover:  assign-inputs($buttons-list, hover);
+
+$output-bourbon-deprecation-warnings: $output-bourbon-deprecation-warnings-original;
 
 $all-button-inputs:        $all-buttons;
 $all-button-inputs-active: $all-buttons-active;

--- a/app/assets/stylesheets/addons/_margin.scss
+++ b/app/assets/stylesheets/addons/_margin.scss
@@ -22,8 +22,8 @@
 /// @output `margin`
 
 @mixin margin($vals...) {
-  $deprecation-warnings: $output-bourbon-deprecation-warnings;
+  $user-deprecation-warnings-setting: $output-bourbon-deprecation-warnings;
   $output-bourbon-deprecation-warnings: false !global;
   @include directional-property(margin, false, $vals...);
-  $output-bourbon-deprecation-warnings: $deprecation-warnings !global;
+  $output-bourbon-deprecation-warnings: $user-deprecation-warnings-setting !global;
 }

--- a/app/assets/stylesheets/addons/_margin.scss
+++ b/app/assets/stylesheets/addons/_margin.scss
@@ -22,5 +22,8 @@
 /// @output `margin`
 
 @mixin margin($vals...) {
+  $deprecation-warnings: $output-bourbon-deprecation-warnings;
+  $output-bourbon-deprecation-warnings: false !global;
   @include directional-property(margin, false, $vals...);
+  $output-bourbon-deprecation-warnings: $deprecation-warnings !global;
 }

--- a/app/assets/stylesheets/addons/_padding.scss
+++ b/app/assets/stylesheets/addons/_padding.scss
@@ -22,5 +22,8 @@
 /// @output `padding`
 
 @mixin padding($vals...) {
+  $deprecation-warnings: $output-bourbon-deprecation-warnings;
+  $output-bourbon-deprecation-warnings: false !global;
   @include directional-property(padding, false, $vals...);
+  $output-bourbon-deprecation-warnings: $deprecation-warnings !global;
 }

--- a/app/assets/stylesheets/addons/_padding.scss
+++ b/app/assets/stylesheets/addons/_padding.scss
@@ -22,8 +22,8 @@
 /// @output `padding`
 
 @mixin padding($vals...) {
-  $deprecation-warnings: $output-bourbon-deprecation-warnings;
+  $user-deprecation-warnings-setting: $output-bourbon-deprecation-warnings;
   $output-bourbon-deprecation-warnings: false !global;
   @include directional-property(padding, false, $vals...);
-  $output-bourbon-deprecation-warnings: $deprecation-warnings !global;
+  $output-bourbon-deprecation-warnings: $user-deprecation-warnings-setting !global;
 }

--- a/app/assets/stylesheets/addons/_text-inputs.scss
+++ b/app/assets/stylesheets/addons/_text-inputs.scss
@@ -107,7 +107,7 @@ $text-inputs-list: 'input[type="color"]',
                    'input:not([type])',
                    'textarea';
 
-$output-bourbon-deprecation-warnings-original: $output-bourbon-deprecation-warnings;
+$user-output-deprecation-warnings-setting: $output-bourbon-deprecation-warnings;
 $output-bourbon-deprecation-warnings: false;
 
 $all-text-inputs:        assign-inputs($text-inputs-list);
@@ -115,4 +115,4 @@ $all-text-inputs-active: assign-inputs($text-inputs-list, active);
 $all-text-inputs-focus:  assign-inputs($text-inputs-list, focus);
 $all-text-inputs-hover:  assign-inputs($text-inputs-list, hover);
 
-$output-bourbon-deprecation-warnings: $output-bourbon-deprecation-warnings-original;
+$output-bourbon-deprecation-warnings: $user-output-deprecation-warnings-setting;

--- a/app/assets/stylesheets/addons/_text-inputs.scss
+++ b/app/assets/stylesheets/addons/_text-inputs.scss
@@ -107,7 +107,12 @@ $text-inputs-list: 'input[type="color"]',
                    'input:not([type])',
                    'textarea';
 
+$output-bourbon-deprecation-warnings-original: $output-bourbon-deprecation-warnings;
+$output-bourbon-deprecation-warnings: false;
+
 $all-text-inputs:        assign-inputs($text-inputs-list);
 $all-text-inputs-active: assign-inputs($text-inputs-list, active);
 $all-text-inputs-focus:  assign-inputs($text-inputs-list, focus);
 $all-text-inputs-hover:  assign-inputs($text-inputs-list, hover);
+
+$output-bourbon-deprecation-warnings: $output-bourbon-deprecation-warnings-original;

--- a/app/assets/stylesheets/css3/_font-face.scss
+++ b/app/assets/stylesheets/css3/_font-face.scss
@@ -6,6 +6,9 @@
   $asset-pipeline: $asset-pipeline,
   $file-formats: eot woff2 woff ttf svg) {
 
+  $deprecation-warnings: $output-bourbon-deprecation-warnings;
+  $output-bourbon-deprecation-warnings: false !global;
+
   $font-url-prefix: font-url-prefixer($asset-pipeline);
 
   @font-face {
@@ -21,4 +24,6 @@
       $font-url-prefix
     );
   }
+
+  $output-bourbon-deprecation-warnings: $deprecation-warnings !global;
 }

--- a/app/assets/stylesheets/css3/_font-face.scss
+++ b/app/assets/stylesheets/css3/_font-face.scss
@@ -6,7 +6,7 @@
   $asset-pipeline: $asset-pipeline,
   $file-formats: eot woff2 woff ttf svg) {
 
-  $deprecation-warnings: $output-bourbon-deprecation-warnings;
+  $user-deprecation-warnings-setting: $output-bourbon-deprecation-warnings;
   $output-bourbon-deprecation-warnings: false !global;
 
   $font-url-prefix: font-url-prefixer($asset-pipeline);
@@ -25,5 +25,5 @@
     );
   }
 
-  $output-bourbon-deprecation-warnings: $deprecation-warnings !global;
+  $output-bourbon-deprecation-warnings: $user-deprecation-warnings-setting !global;
 }

--- a/app/assets/stylesheets/functions/_modular-scale.scss
+++ b/app/assets/stylesheets/functions/_modular-scale.scss
@@ -17,8 +17,13 @@ $major-eleventh:   2.667;
 $major-twelfth:    3;
 $double-octave:    4;
 
+$output-bourbon-deprecation-warnings-original: $output-bourbon-deprecation-warnings;
+$output-bourbon-deprecation-warnings: false;
+
 $modular-scale-ratio: $perfect-fourth !default;
 $modular-scale-base: em($em-base) !default;
+
+$output-bourbon-deprecation-warnings: $output-bourbon-deprecation-warnings-original;
 
 @function modular-scale($increment, $value: $modular-scale-base, $ratio: $modular-scale-ratio) {
   $v1: nth($value, 1);

--- a/app/assets/stylesheets/functions/_modular-scale.scss
+++ b/app/assets/stylesheets/functions/_modular-scale.scss
@@ -17,13 +17,13 @@ $major-eleventh:   2.667;
 $major-twelfth:    3;
 $double-octave:    4;
 
-$output-bourbon-deprecation-warnings-original: $output-bourbon-deprecation-warnings;
+$user-output-deprecation-warnings-setting: $output-bourbon-deprecation-warnings;
 $output-bourbon-deprecation-warnings: false;
 
 $modular-scale-ratio: $perfect-fourth !default;
 $modular-scale-base: em($em-base) !default;
 
-$output-bourbon-deprecation-warnings: $output-bourbon-deprecation-warnings-original;
+$output-bourbon-deprecation-warnings: $user-output-deprecation-warnings-setting;
 
 @function modular-scale($increment, $value: $modular-scale-base, $ratio: $modular-scale-ratio) {
   $v1: nth($value, 1);

--- a/app/assets/stylesheets/functions/_px-to-em.scss
+++ b/app/assets/stylesheets/functions/_px-to-em.scss
@@ -8,11 +8,17 @@
     "removed in 5.0.0.";
   }
 
+  $deprecation-warnings: $output-bourbon-deprecation-warnings;
+  $output-bourbon-deprecation-warnings: false !global;
+
   @if not unitless($pxval) {
     $pxval: strip-units($pxval);
   }
   @if not unitless($base) {
     $base: strip-units($base);
   }
+
+  $output-bourbon-deprecation-warnings: $deprecation-warnings !global;
+
   @return ($pxval / $base) * 1em;
 }

--- a/app/assets/stylesheets/functions/_px-to-em.scss
+++ b/app/assets/stylesheets/functions/_px-to-em.scss
@@ -8,7 +8,7 @@
     "removed in 5.0.0.";
   }
 
-  $deprecation-warnings: $output-bourbon-deprecation-warnings;
+  $user-deprecation-warnings-setting: $output-bourbon-deprecation-warnings;
   $output-bourbon-deprecation-warnings: false !global;
 
   @if not unitless($pxval) {
@@ -18,7 +18,7 @@
     $base: strip-units($base);
   }
 
-  $output-bourbon-deprecation-warnings: $deprecation-warnings !global;
+  $output-bourbon-deprecation-warnings: $user-deprecation-warnings-setting !global;
 
   @return ($pxval / $base) * 1em;
 }

--- a/app/assets/stylesheets/functions/_px-to-rem.scss
+++ b/app/assets/stylesheets/functions/_px-to-rem.scss
@@ -8,7 +8,7 @@
     "removed in 5.0.0.";
   }
 
-  $deprecation-warnings: $output-bourbon-deprecation-warnings;
+  $user-deprecation-warnings-setting: $output-bourbon-deprecation-warnings;
   $output-bourbon-deprecation-warnings: false !global;
 
   @if not unitless($pxval) {
@@ -20,7 +20,7 @@
     $base: strip-units($base);
   }
 
-  $output-bourbon-deprecation-warnings: $deprecation-warnings !global;
+  $output-bourbon-deprecation-warnings: $user-deprecation-warnings-setting !global;
 
   @return ($pxval / $base) * 1rem;
 }

--- a/app/assets/stylesheets/functions/_px-to-rem.scss
+++ b/app/assets/stylesheets/functions/_px-to-rem.scss
@@ -8,6 +8,9 @@
     "removed in 5.0.0.";
   }
 
+  $deprecation-warnings: $output-bourbon-deprecation-warnings;
+  $output-bourbon-deprecation-warnings: false !global;
+
   @if not unitless($pxval) {
     $pxval: strip-units($pxval);
   }
@@ -16,5 +19,8 @@
   @if not unitless($base) {
     $base: strip-units($base);
   }
+
+  $output-bourbon-deprecation-warnings: $deprecation-warnings !global;
+
   @return ($pxval / $base) * 1rem;
 }

--- a/app/assets/stylesheets/functions/_transition-property-name.scss
+++ b/app/assets/stylesheets/functions/_transition-property-name.scss
@@ -7,7 +7,7 @@
     "and will be removed in 5.0.0.";
   }
 
-  $deprecation-warnings: $output-bourbon-deprecation-warnings;
+  $user-deprecation-warnings-setting: $output-bourbon-deprecation-warnings;
   $output-bourbon-deprecation-warnings: false !global;
 
   $new-props: ();
@@ -16,7 +16,7 @@
     $new-props: append($new-props, transition-property-name($prop, $vendor), comma);
   }
 
-  $output-bourbon-deprecation-warnings: $deprecation-warnings !global;
+  $output-bourbon-deprecation-warnings: $user-deprecation-warnings-setting !global;
 
   @return $new-props;
 }

--- a/app/assets/stylesheets/functions/_transition-property-name.scss
+++ b/app/assets/stylesheets/functions/_transition-property-name.scss
@@ -7,11 +7,16 @@
     "and will be removed in 5.0.0.";
   }
 
+  $deprecation-warnings: $output-bourbon-deprecation-warnings;
+  $output-bourbon-deprecation-warnings: false !global;
+
   $new-props: ();
 
   @each $prop in $props {
     $new-props: append($new-props, transition-property-name($prop, $vendor), comma);
   }
+
+  $output-bourbon-deprecation-warnings: $deprecation-warnings !global;
 
   @return $new-props;
 }

--- a/app/assets/stylesheets/helpers/_directional-values.scss
+++ b/app/assets/stylesheets/helpers/_directional-values.scss
@@ -69,7 +69,7 @@
 @mixin directional-property($pre, $suf, $vals) {
   @include _bourbon-deprecate("directional-property");
 
-  $deprecation-warnings: $output-bourbon-deprecation-warnings;
+  $user-deprecation-warnings-setting: $output-bourbon-deprecation-warnings;
   $output-bourbon-deprecation-warnings: false !global;
 
   // Property Names
@@ -104,5 +104,5 @@
     #{$all}: $vals;
   }
 
-  $output-bourbon-deprecation-warnings: $deprecation-warnings !global;
+  $output-bourbon-deprecation-warnings: $user-deprecation-warnings-setting !global;
 }

--- a/app/assets/stylesheets/helpers/_directional-values.scss
+++ b/app/assets/stylesheets/helpers/_directional-values.scss
@@ -69,6 +69,9 @@
 @mixin directional-property($pre, $suf, $vals) {
   @include _bourbon-deprecate("directional-property");
 
+  $deprecation-warnings: $output-bourbon-deprecation-warnings;
+  $output-bourbon-deprecation-warnings: false !global;
+
   // Property Names
   $top:    $pre + "-top"    + if($suf, "-#{$suf}", "");
   $bottom: $pre + "-bottom" + if($suf, "-#{$suf}", "");
@@ -100,4 +103,6 @@
   } @else {
     #{$all}: $vals;
   }
+
+  $output-bourbon-deprecation-warnings: $deprecation-warnings !global;
 }

--- a/app/assets/stylesheets/helpers/_gradient-positions-parser.scss
+++ b/app/assets/stylesheets/helpers/_gradient-positions-parser.scss
@@ -4,7 +4,7 @@
     "deprecated and will be removed in 5.0.0.";
   }
 
-  $deprecation-warnings: $output-bourbon-deprecation-warnings;
+  $user-deprecation-warnings-setting: $output-bourbon-deprecation-warnings;
   $output-bourbon-deprecation-warnings: false !global;
 
   @if $gradient-positions
@@ -18,7 +18,7 @@
     $gradient-positions: _radial-positions-parser($gradient-positions);
   }
 
-  $output-bourbon-deprecation-warnings: $deprecation-warnings !global;
+  $output-bourbon-deprecation-warnings: $user-deprecation-warnings-setting !global;
 
   @return $gradient-positions;
 }

--- a/app/assets/stylesheets/helpers/_gradient-positions-parser.scss
+++ b/app/assets/stylesheets/helpers/_gradient-positions-parser.scss
@@ -4,6 +4,9 @@
     "deprecated and will be removed in 5.0.0.";
   }
 
+  $deprecation-warnings: $output-bourbon-deprecation-warnings;
+  $output-bourbon-deprecation-warnings: false !global;
+
   @if $gradient-positions
   and ($gradient-type == linear)
   and (type-of($gradient-positions) != color) {
@@ -14,5 +17,8 @@
   and (type-of($gradient-positions) != color) {
     $gradient-positions: _radial-positions-parser($gradient-positions);
   }
+
+  $output-bourbon-deprecation-warnings: $deprecation-warnings !global;
+
   @return $gradient-positions;
 }

--- a/app/assets/stylesheets/helpers/_linear-angle-parser.scss
+++ b/app/assets/stylesheets/helpers/_linear-angle-parser.scss
@@ -20,12 +20,12 @@
   }
 
   @if $offset {
-    $deprecation-warnings: $output-bourbon-deprecation-warnings;
+    $user-deprecation-warnings-setting: $output-bourbon-deprecation-warnings;
     $output-bourbon-deprecation-warnings: false !global;
 
     $num: _str-to-num($first-val);
 
-    $output-bourbon-deprecation-warnings: $deprecation-warnings !global;
+    $output-bourbon-deprecation-warnings: $user-deprecation-warnings-setting !global;
 
     @return (
       webkit-image: -webkit- + $prefix + ($offset - $num) + $suffix,

--- a/app/assets/stylesheets/helpers/_linear-angle-parser.scss
+++ b/app/assets/stylesheets/helpers/_linear-angle-parser.scss
@@ -20,7 +20,12 @@
   }
 
   @if $offset {
+    $deprecation-warnings: $output-bourbon-deprecation-warnings;
+    $output-bourbon-deprecation-warnings: false !global;
+
     $num: _str-to-num($first-val);
+
+    $output-bourbon-deprecation-warnings: $deprecation-warnings !global;
 
     @return (
       webkit-image: -webkit- + $prefix + ($offset - $num) + $suffix,

--- a/app/assets/stylesheets/helpers/_linear-gradient-parser.scss
+++ b/app/assets/stylesheets/helpers/_linear-gradient-parser.scss
@@ -4,6 +4,9 @@
     "deprecated and will be removed in 5.0.0.";
   }
 
+  $deprecation-warnings: $output-bourbon-deprecation-warnings;
+  $output-bourbon-deprecation-warnings: false !global;
+
   $image: unquote($image);
   $gradients: ();
   $start: str-index($image, "(");
@@ -41,6 +44,8 @@
       spec-image: $image
     );
   }
+
+  $output-bourbon-deprecation-warnings: $deprecation-warnings !global;
 
   @return $gradients;
 }

--- a/app/assets/stylesheets/helpers/_linear-gradient-parser.scss
+++ b/app/assets/stylesheets/helpers/_linear-gradient-parser.scss
@@ -4,7 +4,7 @@
     "deprecated and will be removed in 5.0.0.";
   }
 
-  $deprecation-warnings: $output-bourbon-deprecation-warnings;
+  $user-deprecation-warnings-setting: $output-bourbon-deprecation-warnings;
   $output-bourbon-deprecation-warnings: false !global;
 
   $image: unquote($image);
@@ -45,7 +45,7 @@
     );
   }
 
-  $output-bourbon-deprecation-warnings: $deprecation-warnings !global;
+  $output-bourbon-deprecation-warnings: $user-deprecation-warnings-setting !global;
 
   @return $gradients;
 }

--- a/app/assets/stylesheets/helpers/_linear-positions-parser.scss
+++ b/app/assets/stylesheets/helpers/_linear-positions-parser.scss
@@ -4,6 +4,9 @@
     "deprecated and will be removed in 5.0.0.";
   }
 
+  $deprecation-warnings: $output-bourbon-deprecation-warnings;
+  $output-bourbon-deprecation-warnings: false !global;
+
   $type: type-of(nth($pos, 1));
   $spec: null;
   $degree: null;
@@ -55,6 +58,9 @@
   }
   $degree: unquote($degree + ",");
   $spec:   unquote($spec + ",");
+
+  $output-bourbon-deprecation-warnings: $deprecation-warnings !global;
+
   @return $degree $spec;
 }
 

--- a/app/assets/stylesheets/helpers/_linear-positions-parser.scss
+++ b/app/assets/stylesheets/helpers/_linear-positions-parser.scss
@@ -4,7 +4,7 @@
     "deprecated and will be removed in 5.0.0.";
   }
 
-  $deprecation-warnings: $output-bourbon-deprecation-warnings;
+  $user-deprecation-warnings-setting: $output-bourbon-deprecation-warnings;
   $output-bourbon-deprecation-warnings: false !global;
 
   $type: type-of(nth($pos, 1));
@@ -59,7 +59,7 @@
   $degree: unquote($degree + ",");
   $spec:   unquote($spec + ",");
 
-  $output-bourbon-deprecation-warnings: $deprecation-warnings !global;
+  $output-bourbon-deprecation-warnings: $user-deprecation-warnings-setting !global;
 
   @return $degree $spec;
 }

--- a/app/assets/stylesheets/helpers/_linear-side-corner-parser.scss
+++ b/app/assets/stylesheets/helpers/_linear-side-corner-parser.scss
@@ -5,7 +5,7 @@
     "deprecated and will be removed in 5.0.0.";
   }
 
-  $deprecation-warnings: $output-bourbon-deprecation-warnings;
+  $user-deprecation-warnings-setting: $output-bourbon-deprecation-warnings;
   $output-bourbon-deprecation-warnings: false !global;
 
   $val-1: str-slice($first-val, 1, $has-multiple-vals - 1);
@@ -21,7 +21,7 @@
   $pos: _position-flipper($val-1) _position-flipper($val-2) _position-flipper($val-3);
   $pos: unquote($pos + "");
 
-  $output-bourbon-deprecation-warnings: $deprecation-warnings !global;
+  $output-bourbon-deprecation-warnings: $user-deprecation-warnings-setting !global;
 
   // Use old spec for webkit
   @if $val-1 == "to" {

--- a/app/assets/stylesheets/helpers/_linear-side-corner-parser.scss
+++ b/app/assets/stylesheets/helpers/_linear-side-corner-parser.scss
@@ -5,6 +5,9 @@
     "deprecated and will be removed in 5.0.0.";
   }
 
+  $deprecation-warnings: $output-bourbon-deprecation-warnings;
+  $output-bourbon-deprecation-warnings: false !global;
+
   $val-1: str-slice($first-val, 1, $has-multiple-vals - 1);
   $val-2: str-slice($first-val, $has-multiple-vals + 1, str-length($first-val));
   $val-3: null;
@@ -17,6 +20,8 @@
 
   $pos: _position-flipper($val-1) _position-flipper($val-2) _position-flipper($val-3);
   $pos: unquote($pos + "");
+
+  $output-bourbon-deprecation-warnings: $deprecation-warnings !global;
 
   // Use old spec for webkit
   @if $val-1 == "to" {

--- a/app/assets/stylesheets/helpers/_radial-positions-parser.scss
+++ b/app/assets/stylesheets/helpers/_radial-positions-parser.scss
@@ -4,7 +4,7 @@
     "deprecated and will be removed in 5.0.0.";
   }
 
-  $deprecation-warnings: $output-bourbon-deprecation-warnings;
+  $user-deprecation-warnings-setting: $output-bourbon-deprecation-warnings;
   $output-bourbon-deprecation-warnings: false !global;
 
   $shape-size: nth($gradient-pos, 1);
@@ -22,7 +22,7 @@
     $spec: "#{$spec},";
   }
 
-  $output-bourbon-deprecation-warnings: $deprecation-warnings !global;
+  $output-bourbon-deprecation-warnings: $user-deprecation-warnings-setting !global;
 
   @return $pre-spec $spec;
 }

--- a/app/assets/stylesheets/helpers/_radial-positions-parser.scss
+++ b/app/assets/stylesheets/helpers/_radial-positions-parser.scss
@@ -4,6 +4,9 @@
     "deprecated and will be removed in 5.0.0.";
   }
 
+  $deprecation-warnings: $output-bourbon-deprecation-warnings;
+  $output-bourbon-deprecation-warnings: false !global;
+
   $shape-size: nth($gradient-pos, 1);
   $pos:        nth($gradient-pos, 2);
   $shape-size-spec: _shape-size-stripper($shape-size);
@@ -18,6 +21,8 @@
   @if ($spec != "  ") {
     $spec: "#{$spec},";
   }
+
+  $output-bourbon-deprecation-warnings: $deprecation-warnings !global;
 
   @return $pre-spec $spec;
 }


### PR DESCRIPTION
### What does this PR do?

Suppresses deprecation warnings when deprecated functions or mixins from other bourbon functions or mixins. This will stop a lot of confusion when people suddenly see loads of deprecation warnings for functions or mixins they didn't use directly.

### If this is related to an existing issue, include a link to it as well.
Solves: #1001