### PR TITLE
Configure hound to ignore `///` comment style

### DIFF
--- a/.scss-lint.yml
+++ b/.scss-lint.yml
@@ -171,6 +171,10 @@ linters:
     enabled: true
     style: one_space
 
+  SpaceAfterComment:
+    enabled: false
+    allow_empty_comments: true
+
   SpaceAfterPropertyColon:
     enabled: true
     style: one_space


### PR DESCRIPTION
### What does this PR do?
Sassdoc uses a triple dash comment style to mark its content.
Hound keeps barking at it every time a pr is posted that involves any documentation.

<img width="765" alt="screen shot 2017-02-12 at 11 33 41 pm" src="https://cloud.githubusercontent.com/assets/2489247/22871098/b60c8bde-f17b-11e6-9d7e-c237f4516e58.png">
