### PR TITLE
Drop patch level from dependency version numbers

### DIFF
--- a/bourbon.gemspec
+++ b/bourbon.gemspec
@@ -3,12 +3,12 @@ require "bourbon/version"
 
 Gem::Specification.new do |s|
   s.add_development_dependency "aruba", "~> 0.6.2"
-  s.add_development_dependency "css_parser", "~> 1.4.1"
-  s.add_development_dependency "rake", "~> 11.1.2"
-  s.add_development_dependency "rspec", "~> 3.4.0"
-  s.add_development_dependency "scss_lint", "0.48.0"
-  s.add_runtime_dependency "sass", "~> 3.4.22"
-  s.add_runtime_dependency "thor", "~> 0.19.1"
+  s.add_development_dependency "css_parser", "~> 1.4"
+  s.add_development_dependency "rake", "~> 11.1"
+  s.add_development_dependency "rspec", "~> 3.4"
+  s.add_development_dependency "scss_lint", "0.48"
+  s.add_runtime_dependency "sass", "~> 3.4"
+  s.add_runtime_dependency "thor", "~> 0.19"
   s.authors = [
     "Christian Reuter",
     "Damian Galarza",


### PR DESCRIPTION
By dropping the patch level from a pessimistic version constraint, we
allow the gems to automatically update to minor releases within a major
release cycle. This is to say:

- "~> 3.4.22" is equal to [">= 3.4.0", "< 3.5.0"]
- "~> 3.4" is equal to [">= 3.4.0", "< 4.0.0"]

See: http://guides.rubygems.org/patterns/#pessimistic-version-constraint