### PR TITLE
Fix link destination for box-sizing mixin "View Source"

### DIFF
--- a/_includes/mixins/box-sizing.html
+++ b/_includes/mixins/box-sizing.html
@@ -1,7 +1,7 @@
 <article id="box-sizing" data-type="mixin">
   <header class="title-bar">
     <h2 class="title">Box Sizing</h2>
-    <a class="view-source" href="//github.com/thoughtbot/bourbon/blob/v4-stable/app/assets/stylesheets/css3/_box-sizing.scss">View source</a>
+    <a class="view-source" href="//github.com/thoughtbot/bourbon/blob/v4-stable/app/assets/stylesheets/_bourbon-deprecated-upcoming.scss#L421-L425">View source</a>
     <a class="view-spec" href="//developer.mozilla.org/en-US/docs/Web/CSS/box-sizing">View spec</a>
   </header>
   <p class="alert"><b>Deprecation Warning:</b> This mixin has been deprecated and will be removed in v5.0.</p>


### PR DESCRIPTION
"View Source" was pointing to a dead location on GitHub.

Close #1018.

### What does this PR do?

Resolves a documentation issue.

### If this is related to an existing issue, include a link to it as well.

Fixes issue #1018.

### Screenshots (if relevant)

![screenshot 2017-03-29 10 59 12](https://cloud.githubusercontent.com/assets/319471/24461340/c1cf0d28-146e-11e7-8306-a09a05af3626.png)

