### PR TITLE
Use Sass.load_paths instead of SASS_PATH env

### DIFF
--- a/lib/bourbon.rb
+++ b/lib/bourbon.rb
@@ -1,7 +1,4 @@
+require "sass"
 require "bourbon/generator"
 
-bourbon_path = File.expand_path("../../core", __FILE__)
-ENV["SASS_PATH"] = [
-  ENV["SASS_PATH"],
-  bourbon_path,
-].compact.join(File::PATH_SEPARATOR)
+Sass.load_paths << File.expand_path("../../core", __FILE__)


### PR DESCRIPTION
The SASS_PATH environment variable is not intended to be set by another
library but rather by consumers of Sass. Since the environment variable
is only read in once at the first time `load_paths` is called.

This was causing an error where, if a user had another gem such as
`bootstrap-sass` and it was being loaded before `bourbon` was, the
modifications to `SASS_PATH` we were making were never read in, so the
bourbon files would never be found.