### PR TITLE
Improve issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,11 +1,22 @@
-### Expected behavior
+<!-- Feel free to remove any part of this issue template that is not relevant -->
+<!-- Providing context helps us come up with a useful solution -->
 
-### Actual behavior
+## Description
 
-### Steps to reproduce behavior
+<!-- What did you expect to happen? What happened instead? Was a specific error thrown? -->
 
-### Bourbon version
+## Steps to Reproduce
 
-### Environment info
+<!-- If you can reproduce the bug in a CodePen, link to it here -->
 
-### Screenshots (if relevant)
+1. Step 1…
+2.
+3.
+
+## Development Environment
+
+<!--- Include as many relevant details about the environment you experienced the bug in -->
+
+- Bourbon version:
+- Platform:
+- Link to the code repository:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,10 @@
-### What does this PR do?
+<!-- Feel free to remove any part of this pull request template that is not relevant -->
 
-### If this is related to an existing issue, include a link to it as well.
+## Description
 
-### Screenshots (if relevant)
+<!-- What do your changes do or fix? -->
+
+## Additional Information
+
+<!-- Links to demos, e.g. CodePen, can be helpful, as are research and support documents -->
+<!-- If this fixes or is related to an existing issue, link to it here (and in the commit message) -->


### PR DESCRIPTION
- Add comments to better describe what we would like to see
- Simplify issue template with less sections
- Encourage people to provide links to code, CodePens, etc.
- Remove ask for screenshots, because most of Bourbon is not visual
- Based on work by 18F and the Government Digital Service:
  - https://github.com/18F/web-design-standards/tree/develop/.github
  - https://github.com/alphagov/govuk_frontend_alpha/tree/master/.github

Closes https://github.com/thoughtbot/bourbon/issues/946