### PR TITLE
improve gamma approximation

### DIFF
--- a/core/bourbon/utilities/_gamma.scss
+++ b/core/bourbon/utilities/_gamma.scss
@@ -2,8 +2,7 @@
 
 /// Performs gamma correction on a single color channel.
 ///
-/// Note that Sass does not have a `pow()` function, so the calculation
-/// is approximate.
+/// Note thatthe calculation is approximate if a `pow()` is not available.
 ///
 /// @argument {number (0-1)} $channel
 ///
@@ -16,6 +15,10 @@
     @return $channel / 12.92;
   } @else {
     $c: ($channel + 0.055) / 1.055;
-    @return (133 * $c * $c * $c + 155 * $c * $c) / 288;
+    @if function-exists('pow') {
+      @return pow($c, 2.4);
+    } @else {
+      @return 0.56 * $c * $c * $c + 0.44 * $c * $c;
+    }
   }
 }

--- a/core/bourbon/utilities/_gamma.scss
+++ b/core/bourbon/utilities/_gamma.scss
@@ -2,7 +2,7 @@
 
 /// Performs gamma correction on a single color channel.
 ///
-/// Note thatthe calculation is approximate if a `pow()` is not available.
+/// Note that the calculation is approximate if a `pow()` is not available.
 ///
 /// @argument {number (0-1)} $channel
 ///
@@ -15,7 +15,7 @@
     @return $channel / 12.92;
   } @else {
     $c: ($channel + 0.055) / 1.055;
-    @if function-exists('pow') {
+    @if function-exists("pow") {
       @return pow($c, 2.4);
     } @else {
       @return 0.56 * $c * $c * $c + 0.44 * $c * $c;


### PR DESCRIPTION
## Description

In #935 I added a WCAG compliant contrast implementation. In order to calculate gamma corrected values I used an approximation of `pow($c, 2.4)`. Unfortunately, I later realized that this approximation is not as good as I had thought.

The approxomation is actually optimal if you only look at `_gamma()`. But the resulting values are later used to calculate a contrast, which amplifies certain errors made in this step. So I changed two things about the approximation:

- use `pow()` if available (e.g. from sass-planifolia or MathSass)
- use an approximation that is optimized to produce good contrast values

## Additional Information

See also https://github.com/oddbird/accoutrement-color/pull/6 for a similar change.