### PR TITLE
Fix SassC::Rails integration

### DIFF
--- a/lib/bourbon.rb
+++ b/lib/bourbon.rb
@@ -1,4 +1,12 @@
 require "sass"
 require "bourbon/generator"
 
-Sass.load_paths << File.expand_path("../../core", __FILE__)
+module Bourbon
+  if defined?(Rails) && defined?(Rails::Engine)
+    class Engine < ::Rails::Engine
+      config.assets.paths << File.expand_path("../../core", __FILE__)
+    end
+  else
+    Sass.load_paths << File.expand_path("../../core", __FILE__)
+  end
+end


### PR DESCRIPTION
SassC does not appear to look in Sass.load_paths, so instead we must register bourbon with the asset pipeline.

Fixes #1047