### PR TITLE
Fix failing Cucumber test, update Aruba, Cucumber

### DIFF
--- a/bourbon.gemspec
+++ b/bourbon.gemspec
@@ -2,8 +2,9 @@ $:.push File.expand_path("../lib", __FILE__)
 require "bourbon/version"
 
 Gem::Specification.new do |s|
-  s.add_development_dependency "aruba", "~> 0.6.2"
+  s.add_development_dependency "aruba", "~> 0.14"
   s.add_development_dependency "css_parser", "~> 1.4"
+  s.add_development_dependency "cucumber", "~> 2.0"
   s.add_development_dependency "rake", "~> 11.1"
   s.add_development_dependency "rspec", "~> 3.4"
   s.add_development_dependency "scss_lint", "0.48"

--- a/features/install.feature
+++ b/features/install.feature
@@ -1,4 +1,3 @@
-@disable-bundler
 Feature: Install bourbon files
 
   Scenario: Bourbon generates a new bourbon installation

--- a/features/step_definitions/bourbon_steps.rb
+++ b/features/step_definitions/bourbon_steps.rb
@@ -14,17 +14,19 @@ Then /^the sass directories(?: with "([^"]+)" prefix)? should have been generate
     "bourbon/validators",
   ]
   sass_directories.map!{ |directory| bourbon_path(prefix, directory) }
-  check_directory_presence(sass_directories, true)
+  sass_directories.each do |sass_directory|
+    expect(sass_directory).to be_an_existing_directory
+  end
 end
 
 Then /^the master bourbon partial should have been generated(?: within "([^"]+)" directory)?$/ do |prefix|
-  check_file_presence([bourbon_path(prefix, '_bourbon.scss')], true)
+  expect(bourbon_path(prefix, "_bourbon.scss")).to be_an_existing_file
 end
 
 Then /^bourbon should not have been generated$/ do
-  check_directory_presence(['bourbon'], false)
+  expect("bourbon").not_to be_an_existing_directory
 end
 
 Then /^the output should contain the current version of Bourbon$/ do
-  assert_exact_output("Bourbon #{Bourbon::VERSION}\n", all_output)
+  expect(last_command_started).to have_output "Bourbon #{Bourbon::VERSION}"
 end

--- a/features/update.feature
+++ b/features/update.feature
@@ -1,4 +1,3 @@
-@disable-bundler
 Feature: Update bourbon files
 
   Scenario: Updating updates an existing bourbon install

--- a/features/version.feature
+++ b/features/version.feature
@@ -1,6 +1,4 @@
-@disable-bundler
 Feature: Show version
   Scenario: Viewing version
     When I successfully run `bundle exec bourbon --version`
     Then the output should contain the current version of Bourbon
-


### PR DESCRIPTION
By having the `@disable-bundler` hook, the `bourbon` command was not
being found in the tests. Our theory is that this is due to a change in
the `@disable-bundler` hook that improves isolation of gems defined in
the `Gemfile.lock` when working within a gem.