### PR TITLE
Modify order of the parameters in the code comment

### DIFF
--- a/core/bourbon/library/_font-face.scss
+++ b/core/bourbon/library/_font-face.scss
@@ -9,14 +9,14 @@
 ///
 /// @argument {string} $file-path
 ///
+/// @argument {string | list} $file-formats [("ttf", "woff2", "woff")]
+///   List of the font file formats to include. Can also be set globally using
+///   the `global-font-file-formats` key in the Bourbon settings.
+///
 /// @argument {string} $asset-pipeline [false]
 ///   Set to `true` if you’re using the Rails Asset Pipeline (place the fonts
 ///   in `app/assets/fonts/`). Can also be set globally using the
 ///   `rails-asset-pipeline` key in the Bourbon settings.
-///
-/// @argument {string | list} $file-formats [("ttf", "woff2", "woff")]
-///   List of the font file formats to include. Can also be set globally using
-///   the `global-font-file-formats` key in the Bourbon settings.
 ///
 /// @content
 ///   Any additional CSS properties that are included in the `@include`


### PR DESCRIPTION
<!-- Feel free to remove any part of this pull request template that is not relevant -->

## Description


I thought it was often misleading because of the order of comments.
So we modified the order of the parameters in the code comment.
<!-- What do your changes do or fix? -->

## Additional Information

<!-- Links to demos, e.g. CodePen, can be helpful, as are research and support documents -->
<!-- If this fixes or is related to an existing issue, link to it here (and in the commit message) -->
