### PR TITLE
Remove sass dependency

### DIFF
--- a/bourbon.gemspec
+++ b/bourbon.gemspec
@@ -8,7 +8,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake", "~> 11.1"
   s.add_development_dependency "rspec", "~> 3.4"
   s.add_development_dependency "scss_lint", "0.48"
-  s.add_runtime_dependency "sass", "~> 3.4"
   s.add_runtime_dependency "thor", "~> 0.19"
   s.authors = [
     "Christian Reuter",

--- a/lib/bourbon.rb
+++ b/lib/bourbon.rb
@@ -1,4 +1,3 @@
-require "sass"
 require "bourbon/generator"
 
 module Bourbon
@@ -7,6 +6,9 @@ module Bourbon
       config.assets.paths << File.expand_path("../../core", __FILE__)
     end
   else
-    Sass.load_paths << File.expand_path("../../core", __FILE__)
+    begin
+      require "sass"
+      Sass.load_paths << File.expand_path("../../core", __FILE__)
+    rescue LoadError; end
   end
 end


### PR DESCRIPTION
This closes #1064 

Given that Ruby sass is now deprecated and developers are suggested to move to sassc, we should stop specifying sass as a runtime dependency.

Also, since it seems like we required sass only just to add to load_paths, it should be safe to silently fail if it is not available.

Note that there's some caveat about this patch: sassc (or, precisely, sassc-ruby) no longer has `load_paths` setting at the class level. User has to set load_paths themselves [when they create `SassC::Engine` instance](https://github.com/sass/sassc-ruby/blob/61a02d1d88b489f83b5b3d0da48a9b62f210691b/test/custom_importer_test.rb#L81). This probably will affect people who are using sass in ruby but without Rails environment. I currently see no mention of this specific usage the README.md, so I think we shold be fine. (People who uses Rails and Asset Pipeline or Webpack should see no problem as they Railtie continues to work as expect).