### PR TITLE
Refactor `font-face` mixin, improve error handling

### DIFF
--- a/core/bourbon/utilities/_font-source-declaration.scss
+++ b/core/bourbon/utilities/_font-source-declaration.scss
@@ -34,16 +34,20 @@
     svg:   "#{$file-path}.svg##{$font-family}" format("svg"),
   );
 
-  @each $key, $values in $formats-map {
-    @if _contains($file-formats, $key) {
-      $file-path: nth($values, 1);
-      $font-format: nth($values, 2);
+  @each $format in $file-formats {
+    @if _contains(map-keys($formats-map), $format) {
+      $value: map-get($formats-map, $format);
+      $file-path: nth($value, 1);
+      $font-format: nth($value, 2);
 
       @if $asset-pipeline == true {
         $src: append($src, font-url($file-path) $font-format, comma);
       } @else {
         $src: append($src, url($file-path) $font-format, comma);
       }
+    } @else {
+      @error "`#{$file-formats}` contains an unsupported font file format. " +
+             "Must be `eot`, `ttf`, `svg`, `woff` and/or `woff2`.";
     }
   }
 


### PR DESCRIPTION
This refactors the `font-face` mixin so that we can throw a proper and
descriptive error when someone attempts to use it with a font file
format that we do not support (e.g. OTF).

To do so, we change how we handle the mapping of the font file formats
to the `src` that we output. Instead of iterating over our supported
formats map and then checking it against the list that the user passes
into the `$file-formats` argument, we reverse that and work from the
user's input and map it against our `$formats-map`. This allows us to
throw an `@error` if the user expects output from an unsupported format.

Related: https://github.com/thoughtbot/bourbon/issues/1080