### PR TITLE
 Add `var()` and `env()` as valid CSS lengths

### DIFF
--- a/core/bourbon/validators/_is-length.scss
+++ b/core/bourbon/validators/_is-length.scss
@@ -9,7 +9,12 @@
 /// @access private
 
 @function _is-length($value) {
-  @return type-of($value) != "null" and (str-slice($value + "", 1, 4) == "calc"
-       or index(auto inherit initial 0, $value)
-       or (type-of($value) == "number" and not(unitless($value))));
+  @return type-of($value) != "null"
+    and (
+      str-slice($value + "", 1, 4) == "calc"
+      or str-slice($value + "", 1, 3) == "var"
+      or str-slice($value + "", 1, 3) == "env"
+      or index(auto inherit initial 0, $value)
+      or (type-of($value) == "number" and not(unitless($value)))
+   );
 }

--- a/core/bourbon/validators/_is-length.scss
+++ b/core/bourbon/validators/_is-length.scss
@@ -16,5 +16,5 @@
       or str-slice($value + "", 1, 3) == "env"
       or index(auto inherit initial 0, $value)
       or (type-of($value) == "number" and not(unitless($value)))
-   );
+    );
 }

--- a/spec/bourbon/validators/is_length_spec.rb
+++ b/spec/bourbon/validators/is_length_spec.rb
@@ -35,6 +35,18 @@ describe "is-length" do
     end
   end
 
+  context "parses custom properties" do
+    it "returns true" do
+      expect(".var").to have_rule("color: #fff")
+    end
+  end
+
+  context "parses environment variables" do
+    it "returns true" do
+      expect(".env").to have_rule("color: #fff")
+    end
+  end
+
   context "checks if strings can be represented as a length" do
     it "returns false" do
       expect(".string").not_to have_rule("color: #fff")

--- a/spec/fixtures/validators/is-length.scss
+++ b/spec/fixtures/validators/is-length.scss
@@ -26,6 +26,14 @@
   @include color-length(calc(2em - 5px));
 }
 
+.env {
+  @include color-length(env(safe-area-inset-top, 0));
+}
+
+.var {
+  @include color-length(var(--a-custom-property));
+}
+
 .string {
   @include color-length("stringy");
 }


### PR DESCRIPTION
This PR closes #1086, and include tests, despite the fact I couldn’t accomplish the step 2 of the [PR contributing guidelines](https://github.com/thoughtbot/bourbon/blob/master/CONTRIBUTING.md#pull-requests) (I don’t know what `bundle` is, and it appears not to be on my computer).

Now, writing
```scss
@include position(absolute, 5rem var(--my-var) null null);
```
correctly output the `right: var(--my-var);` part instead of skipping it.

Waiting for feedbacks. Feel free to iterate upon this PR. Thanks for your work on Bourbon. 👍