### PR TITLE
Remove The Bourbon Family in ToC

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@ It is…
 - [Installation](#installation)
 - [Command Line Interface](#command-line-interface)
 - [Browser Support](#browser-support)
-- [The Bourbon Family](#the-bourbon-family)
 - [Contributing](#contributing)
 - [License](#license)
 - [About](#about)


### PR DESCRIPTION
## Description

Remove The Bourbon Family in ToC in README.md.

## Additional Information

Follow up of 723628a9e5ced732843d20e533f833c88358f831.

<!-- Links to demos, e.g. CodePen, can be helpful, as are research and support documents -->
<!-- If this fixes or is related to an existing issue, link to it here (and in the commit message) -->
