### PR TITLE
Use CSS revert in hide-visually mixin

### DIFF
--- a/core/bourbon/library/_hide-visually.scss
+++ b/core/bourbon/library/_hide-visually.scss
@@ -66,5 +66,17 @@
     position: static;
     white-space: inherit;
     width: auto;
+
+    @supports (display: revert) {
+      border: revert;
+      clip: revert;
+      clip-path: revert;
+      height: revert;
+      overflow: revert;
+      padding: revert;
+      position: revert;
+      white-space: revert;
+      width: revert;
+    }
   }
 }

--- a/spec/bourbon/library/hide_visually_spec.rb
+++ b/spec/bourbon/library/hide_visually_spec.rb
@@ -29,7 +29,18 @@ describe "hide-visually" do
                 "overflow: visible; " +
                 "position: static; " +
                 "white-space: inherit; " +
-                "width: auto;"
+                "width: auto; " +
+                "@supports (display: revert) { " +
+                "border: revert; " +
+                "clip: revert; " +
+                "clip-path: revert; " +
+                "height: revert; " +
+                "overflow: revert; " +
+                "padding: revert; " +
+                "position: revert; " +
+                "white-space: revert; " +
+                "width: revert; " +
+                "}"
 
       expect(".hide-visually--unhide").to have_ruleset(ruleset)
     end


### PR DESCRIPTION
When the `unhide` value is passed into the `hide-visually` mixin, we
"undo" the CSS we initially set in the mixin by setting default values.
The `revert` value can be used more appropriately here as it will reset
these property values to the cascaded value. Since `revert` is not
fully supported, we wrap its use in an `@supports` query.

https://developer.mozilla.org/en-US/docs/Web/CSS/revert