### PR TITLE
Compatibility with Rails 7

### DIFF
--- a/lib/bourbon.rb
+++ b/lib/bourbon.rb
@@ -3,7 +3,9 @@ require "bourbon/generator"
 module Bourbon
   if defined?(Rails) && defined?(Rails::Engine)
     class Engine < ::Rails::Engine
-      config.assets.paths << File.expand_path("../core", __dir__)
+      initializer "bourbon.paths", group: :all do |app|
+        app.config.assets.paths << File.expand_path("../core", __dir__)
+      end
     end
   else
     begin


### PR DESCRIPTION
<!-- Feel free to remove any part of this pull request template that is not relevant -->

## Description
This change addresses an undefined method error that happens at boot time when the bourbon gem is in the Gemfile. After this change Rails will boot and the files under /core are available to the app.

The problem is with [line 6 in lib/bourbon.rb](https://github.com/thoughtbot/bourbon/blob/10b497371511fb7b9fd399f54817f7da875987f9/lib/bourbon.rb#L6). My guess is that `assets` is not available on `Rails::Engine::Configuration` due to boot changes related to the [Zeitwerk transition](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#applications-need-to-run-in-zeitwerk-mode), and/or related to [Sprockets no longer being a dependency](https://guides.rubyonrails.org/upgrading_ruby_on_rails.html#sprockets-is-now-an-optional-dependency).


