### PR TITLE
Upgrade to Ruby 3.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: cimg/ruby:2.7.6-node
+      - image: cimg/ruby:3.1.3-node
     steps:
       - checkout
       - restore_cache:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-ruby 2.7.6
+ruby 2.7.7
 nodejs 12.16.1

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-ruby 2.7.7
+ruby 3.0.5
 nodejs 12.16.1

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-ruby 3.0.5
+ruby 3.1.3
 nodejs 12.16.1

--- a/bourbon.gemspec
+++ b/bourbon.gemspec
@@ -3,7 +3,7 @@ require "bourbon/version"
 
 Gem::Specification.new do |s|
   s.add_development_dependency "aruba", "~> 0.14"
-  s.add_development_dependency "bundler", "~> 2.4"
+  s.add_development_dependency "bundler", "~> 2.3.26"
   s.add_development_dependency "contracts", "~> 0.17"
   s.add_development_dependency "css_parser", "~> 1.4"
   s.add_development_dependency "cucumber", "~> 8.0"

--- a/bourbon.gemspec
+++ b/bourbon.gemspec
@@ -3,9 +3,10 @@ require "bourbon/version"
 
 Gem::Specification.new do |s|
   s.add_development_dependency "aruba", "~> 0.14"
+  s.add_development_dependency "bundler", "~> 2.4"
   s.add_development_dependency "contracts", "~> 0.17"
   s.add_development_dependency "css_parser", "~> 1.4"
-  s.add_development_dependency "cucumber", "~> 2.0"
+  s.add_development_dependency "cucumber", "~> 8.0"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec", "~> 3.4"
   s.add_development_dependency "sass"

--- a/bourbon.gemspec
+++ b/bourbon.gemspec
@@ -3,6 +3,7 @@ require "bourbon/version"
 
 Gem::Specification.new do |s|
   s.add_development_dependency "aruba", "~> 0.14"
+  s.add_development_dependency "contracts", "~> 0.17"
   s.add_development_dependency "css_parser", "~> 1.4"
   s.add_development_dependency "cucumber", "~> 2.0"
   s.add_development_dependency "rake"


### PR DESCRIPTION
## Description

Ruby 2.7 is reaching its end-of-life in March 2023. To ensure that we are working with up-to-date versions that receive security updates, we are upgrading our ruby version to 3.1.

As we are upgrading our ruby version, dependencies need to be updated to ensure that they are behaving as expected.

The following gems were updated/version-locked:
- `bundler`: v2.2.33 doesn't work well with ruby v3.1 and shows the following warning whenever bundler is called. For that reason, we are using the exact same version as the CI, v2.3.26:
```
Calling 'DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call 'DidYouMean.correct_error(error_name, spell_checker)' instead.
```
- `contracts`: according to the warning during bundling, v0.16 should be used only with ruby v2.x. For ruby v3.x +, we should use v0.17
- `cucumber`: v2.0 has warnings about redefining methods within the gem. So we are using v8.0

