### PR TITLE
Upgrade Ruby to 3.1.0

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-ruby 2.7.6
+ruby 3.1.0
 nodejs 12.16.1

--- a/bourbon.gemspec
+++ b/bourbon.gemspec
@@ -8,6 +8,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec", "~> 3.4"
   s.add_development_dependency "sass"
+  s.add_development_dependency "ruby", "3.1.0"
   s.add_runtime_dependency "thor", "~> 1.0"
   s.authors = [
     "Christian Reuter",


### PR DESCRIPTION
## Description

This PR upgrades Bourbon to use Ruby 3.1.0 and is part of the EOL Ruby upgrade project documented [here](https://trello.com/c/NwSr9xTR/26-upgrade-repos-using-deprecated-ruby-versions).