### PR TITLE
Fix broken thoughtbot logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,6 @@ We love open-source software! See [our other projects][community] or
 [hire us][hire] to design, develop, and grow your product.
 
   [thoughtbot]: https://thoughtbot.com?utm_source=github
-  [thoughtbot-logo]: http://presskit.thoughtbot.com/images/thoughtbot-logo-for-readmes.svg
+  [thoughtbot-logo]: https://thoughtbot.com/brand_assets/93:44.svg
   [community]: https://thoughtbot.com/community?utm_source=github
   [hire]: https://thoughtbot.com/hire-us?utm_source=github


### PR DESCRIPTION
The previous thoughtbot logo link is broken. Replace it with another link used on other thoughtbot repositories.